### PR TITLE
Add method for setting driver module parameters

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@ nvidia_driver_package_state: present
 nvidia_driver_package_version: ''
 nvidia_driver_persistence_mode_on: yes
 nvidia_driver_skip_reboot: no
+nvidia_driver_module_file: /etc/modprobe.d/nvidia.conf
+nvidia_driver_module_params: ''
 
 # RedHat family
 nvidia_driver_rhel_epel_repo_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,12 @@
     enabled: yes
   when: nvidia_driver_package_state != 'absent'
 
+- name: set module parameters
+  template:
+    src: nvidia.conf.j2
+    dest: "{{ nvidia_driver_module_file }}"
+    mode: '0644'
+
 - name: reboot after driver install
   reboot:
   when: install_driver.changed and not nvidia_driver_skip_reboot

--- a/templates/nvidia.conf.j2
+++ b/templates/nvidia.conf.j2
@@ -1,0 +1,1 @@
+{{ nvidia_driver_module_params }}


### PR DESCRIPTION
Allows one to configure kernel module parameters, i.e.

```
nvidia_driver_module_params: |
  options nvidia "NVreg_RestrictProfilingToAdminUsers=0"
```