### PR TITLE
Fix driver installation on CentOS

### DIFF
--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -18,7 +18,7 @@
 
 - name: install driver packages
   yum:
-    name: "{{ nvidia_driver_package_version | ternary('cuda-drivers='+nvidia_driver_package_version, 'cuda-drivers') }}"
+    name: "{{ nvidia_driver_package_version | ternary('nvidia-driver-latest-dkms='+nvidia_driver_package_version, 'nvidia-driver-latest-dkms') }}"
     state: "{{ nvidia_driver_package_state }}"
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
   register: install_driver


### PR DESCRIPTION
The installation process for the NVIDIA Yum repo has changed, so that the package name to install is now `nvidia-driver-latest-dkms` instead of `cuda-drivers`. This PR changes the package name to fix the install process.

See [documentation for CUDA install on RHEL/CentOS](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#redhat-installation).

This PR partially addresses #6 , as it uses the DKMS drivers when doing a RHEL install.

**Note: this should work for both RHEL and CentOS, but I have only tested on CentOS 7.6.1810.**