### PR TITLE
Fix driver upgrades on Ubuntu by adding package pin file

### DIFF
--- a/files/cuda-ubuntu.pin
+++ b/files/cuda-ubuntu.pin
@@ -1,0 +1,3 @@
+Package: *
+Pin: release l=NVIDIA CUDA
+Pin-Priority: 600

--- a/tasks/install-ubuntu.yml
+++ b/tasks/install-ubuntu.yml
@@ -4,6 +4,14 @@
     repo: ppa:graphics-drivers/ppa
     state: absent
 
+- name: add pin file
+  copy:
+    src: "cuda-ubuntu.pin"
+    dest: "/etc/apt/preferences.d/cuda-repository-pin-600"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+
 - name: add key
   apt_key:
     url: "{{ nvidia_driver_ubuntu_cuda_repo_gpgkey_url }}"


### PR DESCRIPTION
If you attempt to use this role to upgrade from a CUDA 10.1 driver to a CUDA 10.2 driver, it will currently fail with the following error:

```
TASK [nvidia.nvidia_driver : install driver packages] ********************************************************************************************************fatal: [virtual-gpu01]: FAILED! => changed=false
  cache_update_time: 1578441095
  cache_updated: false
  msg: |-
    '/usr/bin/apt-get -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"     install 'cuda-drivers=440.33.01-1'' failed: E: Unable to correct problems, you have held broken packages.
  rc: 100
  stderr: |-
    E: Unable to correct problems, you have held broken packages.
  stderr_lines:
  - 'E: Unable to correct problems, you have held broken packages.'
  stdout: |-
    Reading package lists...
    Building dependency tree...
    Reading state information...
    Some packages could not be installed. This may mean that you have
    requested an impossible situation or if you are using the unstable
    distribution that some required packages have not yet been created
    or been moved out of Incoming.
    The following information may help to resolve the situation:

    The following packages have unmet dependencies:
     cuda-drivers : Depends: nvidia-driver-440 (>= 440.33.01) but it is not going to be installed
                    Depends: xserver-xorg-video-nvidia-440 (>= 440.33.01) but it is not going to be installed
  stdout_lines: <omitted>
```

After some debugging, I found that the [documented instructions for setting up the CUDA APT repo](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&target_distro=Ubuntu&target_version=1804&target_type=debnetwork) call for adding an APT pin file which increases the priority of the CUDA repo relative to other repos. When that pin file is present, it prevents the above error from occurring.

This PR adds the pin file when installing the driver, and makes it possible to upgrade cleanly.

## Test plan

I used the virtual cluster functionality in [DeepOps](https://github.com/NVIDIA/deepops) to test this PR.

Procedure:

1. Clone the [DeepOps repository](https://github.com/NVIDIA/deepops) because it already has playbooks using this role.
1. Within DeepOps repo, ran `virtual/vagrant_startup.sh` to launch VMs, including a GPU VM.
1. Bootstrap a functional version of Python on the VMs.
    ```
    ansible-playbook -i virtual/config/inventory playbooks/bootstrap-python.yml
    ```
1. Run the `nvidia-driver.yml` playbook, with `nvidia_driver_package_version=418.87.01-1` to force a CUDA 10.1 driver:
    ```
    ansible-playbook -i virtual/config/inventory playbooks/nvidia-driver.yml -e nvidia_driver_package_version="418.87.01-1"
    ```
1. After it completes, re-run with `nvidia_driver_package_version=440.33.01-1` to force an upgrade.
    ```
    ansible-playbook -i virtual/config/inventory playbooks/nvidia-driver.yml -e nvidia_driver_package_version="440.33.01-1"
    ```

When run with the current master version of this role, it fails with the error shown above. With this PR, the upgrade succeeds.