### PR TITLE
make optional the addition of yum/apt repos

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ nvidia_driver_persistence_mode_on: yes
 nvidia_driver_skip_reboot: no
 nvidia_driver_module_file: /etc/modprobe.d/nvidia.conf
 nvidia_driver_module_params: ''
+nvidia_driver_add_repos: yes
 
 # RedHat family
 nvidia_driver_rhel_epel_repo_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -6,6 +6,7 @@
     baseurl: "{{ nvidia_driver_rhel_epel_repo_baseurl }}"
     gpgkey: "{{ nvidia_driver_rhel_epel_repo_gpgkey }}"
   environment: "{{proxy_env if proxy_env is defined else {}}}"
+  when: nvidia_driver_add_repos | bool
 
 - name: install dependencies
   yum: name=dkms
@@ -17,6 +18,7 @@
     baseurl: "{{ nvidia_driver_rhel_cuda_repo_baseurl }}"
     gpgkey: "{{ nvidia_driver_rhel_cuda_repo_gpgkey }}"
   environment: "{{proxy_env if proxy_env is defined else {}}}"
+  when: nvidia_driver_add_repos | bool
 
 - name: install driver packages
   yum:

--- a/tasks/install-ubuntu.yml
+++ b/tasks/install-ubuntu.yml
@@ -17,6 +17,7 @@
     url: "{{ nvidia_driver_ubuntu_cuda_repo_gpgkey_url }}"
     id: "{{ nvidia_driver_ubuntu_cuda_repo_gpgkey_id }}"
   environment: "{{proxy_env if proxy_env is defined else {}}}"
+  when: nvidia_driver_add_repos | bool
 
 
 - name: add repo
@@ -24,6 +25,7 @@
     repo: "deb {{ nvidia_driver_ubuntu_cuda_repo_baseurl }} /"
     update_cache: yes
   environment: "{{proxy_env if proxy_env is defined else {}}}"
+  when: nvidia_driver_add_repos | bool
 
 - name: install driver packages
   apt:


### PR DESCRIPTION
We use this role to install the driver in our HPC cluster but our compute nodes have no internet access. We provide the yum repos using katello outside of this role. This option allows to choose if the yum repos should be configured by this role or not. 

This PR should not change the current default behavior of this role which is to configure the official repos.