### PR TITLE
On Red Hat systems, re-order install process so kernel update occurs before driver install

### DIFF
--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -26,6 +26,8 @@
         - "kernel-debug-devel"
       state: latest
     environment: "{{proxy_env if proxy_env is defined else {}}}"
+  - name: reboot to pick up the new kernel
+    reboot:
 
 - name: add epel repo
   yum_repository:

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -1,4 +1,32 @@
 ---
+# We have to do this because the CentOS mirrors don't keep kernel-headers, etc
+# for older kernels.
+- name: ensure we have kernel-headers installed for the current kernel
+  block:
+  - name: attempt to install kernel support packages for current version
+    yum:
+      name: "{{ item }}-{{ ansible_kernel }}"
+      state: present
+    with_items:
+    - "kernel-headers"
+    - "kernel-tools"
+    - "kernel-tools-libs"
+    - "kernel-devel"
+    - "kernel-debug-devel"
+    environment: "{{proxy_env if proxy_env is defined else {}}}"
+  rescue:
+  - name: update the kernel to latest version so we have a supported version
+    yum:
+      name:
+        - "kernel"
+        - "kernel-headers"
+        - "kernel-tools"
+        - "kernel-tools-libs"
+        - "kernel-devel"
+        - "kernel-debug-devel"
+      state: latest
+    environment: "{{proxy_env if proxy_env is defined else {}}}"
+
 - name: add epel repo
   yum_repository:
     name: epel
@@ -26,39 +54,3 @@
   register: install_driver
   environment: "{{proxy_env if proxy_env is defined else {}}}"
 
-# The driver package pulls in the latest kernel-headers package, but not the
-# latest kernel. Check to see if there is a mismatch.
-
-- name: check kernel versions
-  yum:
-    list: kernel
-  register: yum_list
-
-- name: register installed kernel version
-  debug:
-    msg: "{{ yum_list.results | selectattr('yumstate', 'equalto', 'installed') | list }}"
-  register: kernel_version
-
-- name: check kernel-headers versions
-  yum:
-    list: kernel-headers
-  register: yum_list
-
-- name: register installed kernel-headers version
-  debug:
-    msg: "{{ yum_list.results | selectattr('yumstate', 'equalto', 'installed') | list }}"
-  register: kernel_headers_version
-
-- name: update kernel if headers don't match
-  yum:
-    name:
-      - kernel
-      - kernel-tools
-      - kernel-tools-libs
-      - kernel-devel
-      - kernel-debug-devel
-      - kernel-headers
-    state: latest
-  register: kernel_update
-  when: kernel_version.msg[0].release != kernel_headers_version.msg[0].release
-  environment: "{{proxy_env if proxy_env is defined else {}}}"


### PR DESCRIPTION
This should address #18.

## Problem statement

The current workflow for installing the driver on Red Hat or CentOS systems looks like this:

1. Install driver, which incidentally pulls in `kernel-headers`
1. Check if `kernel-headers` matches the running kernel
1. If not, update the running kernel and associated packages to the latest version

Unfortunately, CentOS at least doesn't keep a very long archive of the `kernel-headers` package. On the Vagrant box I'm testing (`centos/7` version `1905.1`), the kernel version is `3.10.0-957.12.2.el7.x86_64`, and there is no associated `kernel-headers` available in the mirror:

```
[vagrant@localhost ~]$ sudo yum install kernel-headers-$(uname -r)
...
No package kernel-headers-3.10.0-957.12.2.el7.x86_64 available.
Error: Nothing to do
```

(Annoyingly, this is not entirely reproducible! Some CentOS mirrors keep longer archives of old versions, so occasionally a test might hit a "good" mirror and get lucky.)

The result, in this case, is that this role doesn't give us a working driver install. 😢 After running the role, we end in a state where `kernel-headers` is the latest available version but the running kernel is still older:

```
[vagrant@localhost ~]$ rpm -qa | grep kernel
kernel-headers-3.10.0-1127.19.1.el7.x86_64
kernel-devel-3.10.0-1127.19.1.el7.x86_64
kernel-3.10.0-957.12.2.el7.x86_64
kernel-tools-libs-3.10.0-1127.19.1.el7.x86_64
kernel-debug-devel-3.10.0-1127.19.1.el7.x86_64
kernel-tools-3.10.0-1127.19.1.el7.x86_64
```

Moreover, we can't update the kernel in place because the NVIDIA driver package blocks it:

```
[vagrant@localhost ~]$ sudo yum install kernel-3.10.0-1127.19.1.el7.x86_64
Failed to set locale, defaulting to C
Loaded plugins: fastestmirror, nvidia
Loading mirror speeds from cached hostfile
 * base: mirror.shastacoe.net
 * extras: mirrors.cat.pdx.edu
 * updates: mirrors.sonic.net
Resolving Dependencies
--> Running transaction check
---> Package kernel.x86_64 0:3.10.0-1127.19.1.el7 will be installed
--> Finished Dependency Resolution
NVIDIA: No kernel module package kmod-nvidia-branch-450 for kernel-3.10.0-1127.19.1.el7.x86_64 and 3:nvidia-driver-branch-450-450.51.06-1.el7.x86_64 found. Ignoring the new kernel
```

To resolve this, the best path is to uninstall the driver, update the kernel, and reinstall the driver, which is obviously a pain.

## Changes in this PR

This PR re-orders the workflow of the install so that instead, we will:

1. Attempt to install `kernel-headers` and other support packages in a version which match the running kernel
1. If this fails, we update the kernel and associated packages and reboot the node
1. After this reboot, we then install the NVIDIA driver on the updated kernel, already running

As a bonus, this avoids a kernel update in the case where we can fetch the `kernel-headers` package which matches the currently running kernel.

## Test plan

1. Set up a CentOS machine with a GPU and which is running an older kernel. The `centos/7: 1905.1` Vagrant box works well for this.
1. On your ansible host, the installed `nvidia.nvidia_driver` role to the version from this PR.
1. Run a playbook which includes this role. (I'm using the [one from DeepOps](https://github.com/NVIDIA/deepops/blob/master/playbooks/nvidia-driver.yml).)

After running, your host should have a working driver install!