### PR TITLE
Allow Ubuntu versions to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ $ ansible-galaxy install nvidia.nvidia_driver
 | Variable | Default value | Description |
 | -------- | ------------- | ----------- |
 | `nvidia_driver_package_state` | `"present"` | Package state for NVIDIA driver packages |
+| `nvidia_driver_major_package_version` | `""` | Major version to install. e.g. 450. |
 | `nvidia_driver_package_version` | `""` | Package version to install. Note that this should match the actual version of the deb or RPM package to be installed. |
 | `nvidia_driver_persistence_mode_on` | `yes` | Whether to enable persistence mode (boolean) |
 | `nvidia_driver_skip_reboot` | `no` | Whether to skip rebooting the node during the install |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 nvidia_driver_package_state: present
+nvidia_driver_major_package_version: ''
 nvidia_driver_package_version: ''
 nvidia_driver_persistence_mode_on: yes
 nvidia_driver_skip_reboot: no

--- a/tasks/install-ubuntu.yml
+++ b/tasks/install-ubuntu.yml
@@ -27,7 +27,7 @@
 
 - name: install driver packages
   apt:
-    name: "{{ nvidia_driver_package_version | ternary('cuda-drivers='+nvidia_driver_package_version, 'cuda-drivers') }}"
+    name: "{{ nvidia_driver_package_version | ternary('cuda-drivers-'+nvidia_driver_major_package_version+'='+nvidia_driver_package_version, 'cuda-drivers') }}"
     state: "{{ nvidia_driver_package_state }}"
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
     purge: "{{ nvidia_driver_package_state == 'absent' }}"


### PR DESCRIPTION
Current version method does not work for Ubuntu.  Providing package version results in a conflict with apt.  For example setting to utilize the dpkg version fails as cuda-drivers-450 is required for the packages to resolve as expected (see below).

PR adds a new albeit duplicitous variable for `nvidia_driver_major_package_version`

Tested on Ubuntu 18.04 LTS and Ubuntu 20.04 LTS.  If acceptable I can also test and update the RHEL if you're interested.


```
    vars:
      nvidia_driver_package_version: "450.51.05-1"
```


```
fatal: [remote]: FAILED! => {"cache_update_time": 1607652683, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"      install 'cuda-drivers=450.51.05-1'' failed: E: Unable to correct problems, you have held broken packages.\n", "rc": 100, "stderr": "E: Unable to correct problems, you have held broken packages.\n", "stderr_lines": ["E: Unable to correct problems, you have held broken packages."], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSome packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n cuda-drivers : Depends: cuda-drivers-450 (= 450.51.05-1) but 450.80.02-1 is to be installed\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "Some packages could not be installed. This may mean that you have", "requested an impossible situation or if you are using the unstable", "distribution that some required packages have not yet been created", "or been moved out of Incoming.", "The following information may help to resolve the situation:", "", "The following packages have unmet dependencies:", " cuda-drivers : Depends: cuda-drivers-450 (= 450.51.05-1) but 450.80.02-1 is to be installed"]}
```