### PR TITLE
Invoking yum once while using a loop via squash_actions is deprecated.

### DIFF
--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -5,14 +5,13 @@
   block:
   - name: attempt to install kernel support packages for current version
     yum:
-      name: "{{ item }}-{{ ansible_kernel }}"
+      name:
+        - "kernel-headers-{{ ansible_kernel }}
+        - "kernel-tools-{{ ansible_kernel }}"
+        - "kernel-tools-libs-{{ ansible_kernel }}"
+        - "kernel-devel-{{ ansible_kernel }}"
+        - "kernel-debug-devel-{{ ansible_kernel }}"
       state: present
-    with_items:
-    - "kernel-headers"
-    - "kernel-tools"
-    - "kernel-tools-libs"
-    - "kernel-devel"
-    - "kernel-debug-devel"
     environment: "{{proxy_env if proxy_env is defined else {}}}"
   rescue:
   - name: update the kernel to latest version so we have a supported version


### PR DESCRIPTION
Signed-off-by: Jonathan Sherry <jonathanrsherry@gmail.com>

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.