### PR TITLE
Use Fedora EPEL package to enable EPEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ $ ansible-galaxy install nvidia.nvidia_driver
 
 | Variable | Default value | Description |
 | -------- | ------------- | ----------- |
-| `nvidia_driver_rhel_epel_repo_baseurl` | `"https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"` | Base URL to use for EPEL repo |
-| `nvidia_driver_rhel_epel_repo_gpgkey` | `"https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"` | GPG key for the EPEL repo |
+| `epel_package` | `"https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"` | Package to install to enable EPEL |
 | `nvidia_driver_rhel_cuda_repo_baseurl` | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"` | Base URL to use for CUDA repo |
 | `nvidia_driver_rhel_cuda_repo_gpgkey` | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/7fa2af80.pub"` | GPG key for the CUDA repo |
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ nvidia_driver_module_params: ''
 ##############################################################################
 # RedHat family                                                              #
 ##############################################################################
+epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
 nvidia_driver_rhel_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"
 nvidia_driver_rhel_cuda_repo_gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/7fa2af80.pub"
 

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -32,7 +32,7 @@
   become: true
   yum:
     name: 
-      - "epel-release"
+      - "{{ epel_package }}"
     state: latest
   environment: "{{proxy_env if proxy_env is defined else {}}}"
 


### PR DESCRIPTION
Making this consistent with DeepOps so everything works on RHEL and can be configured with the same var (`epel_package`)