### PR TITLE
Fix repository base url of Ubuntu.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,5 +32,5 @@ nvidia_driver_ubuntu_packages:
 # Installing with CUDA repositories
 nvidia_driver_ubuntu_cuda_repo_gpgkey_url: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}/7fa2af80.pub"
 nvidia_driver_ubuntu_cuda_repo_gpgkey_id: "7fa2af80"
-nvidia_driver_ubuntu_cuda_repo_baseurl: "http://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"
+nvidia_driver_ubuntu_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"
 nvidia_driver_ubuntu_cuda_package: "cuda-drivers"


### PR DESCRIPTION
Environment:
- Ubuntu 20.04 LTS
- Ansible 2.11.4
- ansible-role-nvidia-driver: v2.0.1

When `nvidia_driver_ubuntu_install_from_cuda_repo` is yes, I got the following error:

Playbook

```yaml
- name: Install NVIDIA Driver
  hosts: hogehoge

  roles:
    - role: nvidia.nvidia_driver
      tags: "nvidia"
      vars:
        - nvidia_driver_ubuntu_install_from_cuda_repo: yes
        - nvidia_driver_package_version: "465.19.01-1"
        - nvidia_driver_skip_reboot: yes
```

Error

```
TASK [nvidia.nvidia_driver : add repo] ****************************************************************************************************
fatal: [hogehoge]: FAILED! => changed=false 
  msg: 'Failed to update apt cache: E:Failed to fetch https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/by-hash/SHA256/751939d95516afc289908a19e447f0acc1506367f72ed356431a2b1a469cc8ca  404  Not Found [IP: 152.199.39.144 443], E:Some index files failed to download. They have been ignored, or old ones used instead.'
```

On the NVIDIA official page, the URL is HTTPS, but before modification it is HTTP.

https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=20.04&target_type=deb_network