### PR TITLE
Add EPEL repo GPG key

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ nvidia_driver_module_params: ''
 # RedHat family                                                              #
 ##############################################################################
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+epel_repo_key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 nvidia_driver_rhel_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"
 nvidia_driver_rhel_cuda_repo_gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/7fa2af80.pub"
 

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -28,6 +28,11 @@
   - name: reboot to pick up the new kernel
     reboot:
 
+- name: add epel repo gpg key
+  rpm_key:
+    key: "{{ epel_repo_key }}"
+    state: present
+
 - name: add epel repo
   become: true
   yum:


### PR DESCRIPTION
Fixes error: "Failed to validate GPG signature for epel-release-8-13.el8.noarch" on CentOS 8. 