### PR TITLE
make optional the addition of yum/apt repos 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ nvidia_driver_persistence_mode_on: yes
 nvidia_driver_skip_reboot: no
 nvidia_driver_module_file: /etc/modprobe.d/nvidia.conf
 nvidia_driver_module_params: ''
+nvidia_driver_add_repos: yes
 
 
 ##############################################################################

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -32,14 +32,16 @@
   rpm_key:
     key: "{{ epel_repo_key }}"
     state: present
+  when: nvidia_driver_add_repos | bool
 
 - name: add epel repo
   become: true
   yum:
-    name: 
+    name:
       - "{{ epel_package }}"
     state: latest
   environment: "{{proxy_env if proxy_env is defined else {}}}"
+  when: nvidia_driver_add_repos | bool
 
 - name: install dependencies
   yum: name=dkms
@@ -51,6 +53,7 @@
     baseurl: "{{ nvidia_driver_rhel_cuda_repo_baseurl }}"
     gpgkey: "{{ nvidia_driver_rhel_cuda_repo_gpgkey }}"
   environment: "{{proxy_env if proxy_env is defined else {}}}"
+  when: nvidia_driver_add_repos | bool
 
 - name: install driver packages RHEL/CentOS 7 and older
   yum:

--- a/tasks/install-ubuntu-cuda-repo.yml
+++ b/tasks/install-ubuntu-cuda-repo.yml
@@ -11,12 +11,14 @@
     owner: "root"
     group: "root"
     mode: "0644"
+  when: nvidia_driver_add_repos | bool
 
 - name: add key
   apt_key:
     url: "{{ nvidia_driver_ubuntu_cuda_repo_gpgkey_url }}"
     id: "{{ nvidia_driver_ubuntu_cuda_repo_gpgkey_id }}"
   environment: "{{proxy_env if proxy_env is defined else {}}}"
+  when: nvidia_driver_add_repos | bool
 
 
 - name: add repo
@@ -24,6 +26,7 @@
     repo: "deb {{ nvidia_driver_ubuntu_cuda_repo_baseurl }} /"
     update_cache: yes
   environment: "{{proxy_env if proxy_env is defined else {}}}"
+  when: nvidia_driver_add_repos | bool
 
 - name: install driver packages
   apt:


### PR DESCRIPTION
We use this role to install the driver in our HPC cluster but our compute nodes have no internet access. We provide the yum repos using katello outside of this role. This option allows to choose if the yum repos should be configured by this role or not.

This PR should not change the current default behavior of this role which is to configure the official repos.