### PR TITLE
Explicitly blacklist nouveau when installing from CUDA repos

### DIFF
--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -44,7 +44,14 @@
   when: nvidia_driver_add_repos | bool
 
 - name: install dependencies
-  yum: name=dkms
+  yum:
+    name: dkms
+    state: present
+
+- name: blacklist nouveau
+  kernel_blacklist:
+    name: nouveau
+    state: present
 
 - name: add repo
   yum_repository:

--- a/tasks/install-ubuntu-cuda-repo.yml
+++ b/tasks/install-ubuntu-cuda-repo.yml
@@ -20,6 +20,10 @@
   environment: "{{proxy_env if proxy_env is defined else {}}}"
   when: nvidia_driver_add_repos | bool
 
+- name: blacklist nouveau
+  kernel_blacklist:
+    name: nouveau
+    state: present
 
 - name: add repo
   apt_repository:


### PR DESCRIPTION
Summary
-----------

With apologies to @pescobar and PR #49 ...

While the driver packages should blacklist nouveau, I'm finding that this isn't happening consistently with the CUDA repos -- at least for CentOS 8. 😢 

This PR explicitly blacklists nouveau with Ansible when using the CUDA repos as our package source.


Test plan
----------

Tested successfully using the [DeepOps playbook](https://github.com/NVIDIA/deepops/blob/master/playbooks/nvidia-software/nvidia-driver.yml) and a CentOS 8 VM.