### PR TITLE
Explicitly add support for CentOS/RHEL8 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,5 @@ Currently, this role supports the following Linux distributions:
 * Ubuntu 20.04 LTS
 * CentOS 7
 * Red Hat Enterprise Linux 7
+* CentOS 8
+* Red Hat Enterprise Linux 8


### PR DESCRIPTION
We already updated the Galaxy metadata in #46, but we never updated the README. This PR fixes that!