### PR TITLE
Align default driver branch across all installs and update to r470

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $ ansible-galaxy install nvidia.nvidia_driver
 | `nvidia_driver_skip_reboot` | `no` | Whether to skip rebooting the node during the install |
 | `nvidia_driver_module_file` | `"/etc/modprobe.d/nvidia.conf"` | Filename to use for NVIDIA driver parameters |
 | `nvidia_driver_module_params` | `""` | Parameters to pass to the NVIDIA driver |
+| `nvidia_driver_branch` | `"470"` | Default driver branch to install |
 
 ### Red Hat specific variables
 
@@ -50,8 +51,6 @@ By default, the Canonical repositories will be used, and the driver installed wi
 | Variable | Default value | Description |
 | -------- | ------------- | ----------- |
 | `nvidia_driver_ubuntu_install_from_cuda_repo` | `no` | Flag whether to use the CUDA repo |
-| `nvidia_driver_ubuntu_branch` | `450` | Driver branch to use for the install |
-| `nvidia_driver_ubuntu_packages` | `["nvidia-headless-450-server", "nvidia-headless-450-utils"]` | Package names to install from Canonical repo |
 | `nvidia_driver_ubuntu_cuda_repo_baseurl` | `"http://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"` | Base URL to use for CUDA repo |
 | `nvidia_driver_ubuntu_cuda_repo_gpgkey_url` | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}/7fa2af80.pub"` | GPG key for the CUDA repo |
 | `nvidia_driver_ubuntu_cuda_repo_gpgkey_id` | `"7fa2af80"` | GPG key ID for the CUDA repo |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ nvidia_driver_skip_reboot: no
 nvidia_driver_module_file: /etc/modprobe.d/nvidia.conf
 nvidia_driver_module_params: ''
 nvidia_driver_add_repos: yes
+nvidia_driver_branch: "470"
 
 
 ##############################################################################
@@ -15,16 +16,20 @@ epel_repo_key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansibl
 nvidia_driver_rhel_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"
 nvidia_driver_rhel_cuda_repo_gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/7fa2af80.pub"
 
+nvidia_driver_rhel_branch: "{{ nvidia_driver_branch }}"
+
 
 ##############################################################################
 # Ubuntu                                                                     #
 ##############################################################################
 
+# Driver branch to install with Ubuntu
+nvidia_driver_ubuntu_branch: "{{ nvidia_driver_branch }}"
+
 # Determine if we should install from CUDA repo instead of Canonical repos
 nvidia_driver_ubuntu_install_from_cuda_repo: no
 
 # Installing with Canonical repositories
-nvidia_driver_ubuntu_branch: "450"
 nvidia_driver_ubuntu_packages:
 - "nvidia-headless-{{ nvidia_driver_ubuntu_branch }}-server"
 - "nvidia-utils-{{ nvidia_driver_ubuntu_branch }}-server"
@@ -35,4 +40,4 @@ nvidia_driver_ubuntu_packages:
 nvidia_driver_ubuntu_cuda_repo_gpgkey_url: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}/7fa2af80.pub"
 nvidia_driver_ubuntu_cuda_repo_gpgkey_id: "7fa2af80"
 nvidia_driver_ubuntu_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"
-nvidia_driver_ubuntu_cuda_package: "cuda-drivers"
+nvidia_driver_ubuntu_cuda_package: "cuda-drivers-{{ nvidia_driver_ubuntu_branch }}"

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -57,7 +57,7 @@
 
 - name: install driver packages RHEL/CentOS 7 and older
   yum:
-    name: "{{ nvidia_driver_package_version | ternary('nvidia-driver-latest-dkms-'+nvidia_driver_package_version, 'nvidia-driver-latest-dkms') }}"
+    name: "{{ nvidia_driver_package_version | ternary('nvidia-driver-latest-dkms-'+nvidia_driver_package_version, 'nvidia-driver-branch-'+nvidia_driver_rhel_branch) }}"
     state: "{{ nvidia_driver_package_state }}"
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
   register: install_driver_rhel7
@@ -66,7 +66,7 @@
 
 - name: install driver packages RHEL/CentOS 8 and newer
   dnf:
-    name: "{{ nvidia_driver_package_version | ternary('@nvidia-driver:'+nvidia_driver_package_version, '@nvidia-driver:latest-dkms') }}"
+    name: "{{ nvidia_driver_package_version | ternary('@nvidia-driver:'+nvidia_driver_package_version, '@nvidia-driver:'+nvidia_driver_rhel_branch+'-dkms') }}"
     state: "{{ nvidia_driver_package_state }}"
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
   register: install_driver_rhel8


### PR DESCRIPTION
Summary
----------

- Update default driver branch to [r470, the latest long-term support branch](https://docs.nvidia.com/datacenter/tesla/drivers/#branches)
- Modify CUDA repos install mechanism to use same default driver branch as the Canonical repos

Test plan
----------

### Ubuntu with Canonical repos

Tested on Ubuntu 20.04 with CUDA repo disabled:

```
ansible-playbook -e '{"nvidia_driver_ubuntu_install_from_cuda_repo": false}' --flush-cache -i virtual/config/inventory -l virtual-gpu02 playbooks/nvidia-software/nvidia-driver.yml
```

Validate driver version after install:

```
$ nvidia-smi | head -n3
Tue Dec 14 22:49:42 2021
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.82.01    Driver Version: 470.82.01    CUDA Version: 11.4     |
```

### Ubuntu with CUDA repo

Tested on Ubuntu 20.04 with CUDA repo enabled:

```
ansible-playbook -e '{"nvidia_driver_ubuntu_install_from_cuda_repo": true}' --flush-cache -i virtual/config/inventory -l virtual-gpu01 playbooks/nvidia-software/nvidia-driver.yml
```

Validate driver version after install:

```
$ nvidia-smi | head -n3
Tue Dec 14 22:45:30 2021
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.82.01    Driver Version: 470.82.01    CUDA Version: 11.4     |
```

### CentOS 7 with CUDA repo

```
$ ansible-playbook playbooks/nvidia-software/nvidia-driver.yml -i virtual/config/inventory -l virtual-gpu02
```

Validate installed driver version:

```
$ rpm -qa | grep nvid | head -n1
nvidia-xconfig-branch-470-470.82.01-1.el7.x86_64
```

### CentOS 8 with CUDA repo

We test CentOS 8 separately because we use a YUM module for installing the NVIDIA driver on 8.x.

```
$ ansible-playbook playbooks/nvidia-software/nvidia-driver.yml -i virtual/config/inventory
```

Validate driver version after install:

```
$ rpm -qa | grep nvid | head -n1
nvidia-driver-470.82.01-1.el8.x86_64
```