### PR TITLE
Add Molecule CI test for nvidia driver role

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -1,0 +1,15 @@
+---
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          path: "${{ github.repository }}"
+      - name: molecule
+        uses: robertdebock/molecule-action@2.7.2

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,5 @@
 galaxy_info:
+  namespace: nvidia
   role_name: nvidia_driver
   author: Luke Yeager
   company: NVIDIA

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include ansible-role-nvidia-driver"
+      include_role:
+        name: "ansible-role-nvidia-driver"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,81 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+
+  - name: ubuntu-1804-canonical
+    image: geerlingguy/docker-ubuntu1804-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    pre_build_image: true
+    privileged: true
+    groups:
+    - canonical_repo
+    - ubuntu
+
+  - name: ubuntu-1804-cuda
+    image: geerlingguy/docker-ubuntu1804-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    pre_build_image: true
+    privileged: true
+    groups:
+    - cuda_repo
+    - ubuntu
+
+  - name: ubuntu-2004-canonical
+    image: geerlingguy/docker-ubuntu2004-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    pre_build_image: true
+    privileged: true
+    groups:
+    - canonical_repo
+    - ubuntu
+
+  - name: ubuntu-2004-cuda
+    image: geerlingguy/docker-ubuntu2004-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    pre_build_image: true
+    privileged: true
+    groups:
+    - cuda_repo
+    - ubuntu
+
+  - name: centos-7
+    image: geerlingguy/docker-centos7-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    pre_build_image: true
+    privileged: true
+
+  - name: centos-8
+    image: geerlingguy/docker-centos8-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    pre_build_image: true
+    privileged: true
+
+provisioner:
+  name: ansible
+  ansible_args:
+  - -vv
+  inventory:
+    group_vars:
+      all:
+        nvidia_driver_skip_reboot: true
+      canonical_repo:
+        nvidia_driver_ubuntu_install_from_cuda_repo: false
+      cuda_repo:
+        nvidia_driver_ubuntu_install_from_cuda_repo: true
+verifier:
+  name: ansible

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,10 @@
+---
+- hosts: ubuntu
+  become: yes
+  tasks:
+
+  - name: update apt cache and install gpg-agent
+    apt:
+      update_cache: yes
+      name: gpg-agent
+      state: present

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,10 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+  - name: Example assertion
+    assert:
+      that: true

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -27,6 +27,7 @@
     environment: "{{proxy_env if proxy_env is defined else {}}}"
   - name: reboot to pick up the new kernel
     reboot:
+    when: not nvidia_driver_skip_reboot
 
 - name: add epel repo gpg key
   rpm_key:


### PR DESCRIPTION
Right now this is just a basic "does the install succeed?" test, with no
special verification going on.

- Add auto-generated molecule test
- Configure Molecule to test all of
  - CUDA repo on CentOS 7 and 8
  - CUDA repo on Ubuntu 18.04 and 20.04
  - Canonical repo on Ubuntu 18.04 and 20.04
- Add Github Action to test in CI