### PR TITLE
Fix failing molecule tests

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -57,13 +57,13 @@ platforms:
     pre_build_image: true
     privileged: true
 
-  - name: centos-8
-    image: geerlingguy/docker-centos8-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /sbin/init
-    pre_build_image: true
-    privileged: true
+#  - name: centos-8
+#    image: geerlingguy/docker-centos8-ansible
+#    volumes:
+#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#    command: /sbin/init
+#    pre_build_image: true
+#    privileged: true
 
 provisioner:
   name: ansible

--- a/tasks/install-ubuntu-cuda-repo.yml
+++ b/tasks/install-ubuntu-cuda-repo.yml
@@ -20,6 +20,11 @@
   environment: "{{proxy_env if proxy_env is defined else {}}}"
   when: nvidia_driver_add_repos | bool
 
+- name: esure kmod is installed
+  apt:
+    name: "kmod"
+    state: "present"
+
 - name: blacklist nouveau
   kernel_blacklist:
     name: nouveau


### PR DESCRIPTION
- Disable CentOS 8 tests due to the distro hitting EOL
- Install `kmod` package needed for CUDA install method, which doesn't exist in minimal ubuntu images