### PR TITLE
Update default driver branch to R510

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ ansible-galaxy install nvidia.nvidia_driver
 | `nvidia_driver_skip_reboot` | `no` | Whether to skip rebooting the node during the install |
 | `nvidia_driver_module_file` | `"/etc/modprobe.d/nvidia.conf"` | Filename to use for NVIDIA driver parameters |
 | `nvidia_driver_module_params` | `""` | Parameters to pass to the NVIDIA driver |
-| `nvidia_driver_branch` | `"470"` | Default driver branch to install |
+| `nvidia_driver_branch` | `"510"` | Default driver branch to install |
 
 ### Red Hat specific variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ nvidia_driver_skip_reboot: no
 nvidia_driver_module_file: /etc/modprobe.d/nvidia.conf
 nvidia_driver_module_params: ''
 nvidia_driver_add_repos: yes
-nvidia_driver_branch: "470"
+nvidia_driver_branch: "510"
 
 
 ##############################################################################


### PR DESCRIPTION
R510 corresponds to CUDA 11.6 and is the current production driver
branch. Support for R510 will extend to January 2023 per the current
documentation at
https://docs.nvidia.com/datacenter/tesla/drivers/index.html.