### PR TITLE
Update to new NVIDIA signing key

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ By default, the Canonical repositories will be used, and the driver installed wi
 | -------- | ------------- | ----------- |
 | `nvidia_driver_ubuntu_install_from_cuda_repo` | `no` | Flag whether to use the CUDA repo |
 | `nvidia_driver_ubuntu_cuda_repo_baseurl` | `"http://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"` | Base URL to use for CUDA repo |
-| `nvidia_driver_ubuntu_cuda_repo_gpgkey_url` | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}/7fa2af80.pub"` | GPG key for the CUDA repo |
-| `nvidia_driver_ubuntu_cuda_repo_gpgkey_id` | `"7fa2af80"` | GPG key ID for the CUDA repo |
 | `nvidia_driver_ubuntu_cuda_package` | `"cuda-drivers"` | Package name to install from CUDA repo |
 
 ## Example playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ nvidia_driver_branch: "510"
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
 epel_repo_key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 nvidia_driver_rhel_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"
-nvidia_driver_rhel_cuda_repo_gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/7fa2af80.pub"
+nvidia_driver_rhel_cuda_repo_gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/D42D0685.pub"
 
 nvidia_driver_rhel_branch: "{{ nvidia_driver_branch }}"
 
@@ -37,7 +37,8 @@ nvidia_driver_ubuntu_packages:
 - "nvidia-kernel-source-{{ nvidia_driver_ubuntu_branch }}-server"
 
 # Installing with CUDA repositories
-nvidia_driver_ubuntu_cuda_repo_gpgkey_url: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}/7fa2af80.pub"
-nvidia_driver_ubuntu_cuda_repo_gpgkey_id: "7fa2af80"
+old_nvidia_driver_ubuntu_cuda_repo_gpgkey_id: "7fa2af80"
 nvidia_driver_ubuntu_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"
+nvidia_driver_ubuntu_cuda_keyring_package: "cuda-keyring_1.0-1_all.deb"
+nvidia_driver_ubuntu_cuda_keyring_url: "{{ nvidia_driver_ubuntu_cuda_repo_baseurl }}/{{ nvidia_driver_ubuntu_cuda_keyring_package }}"
 nvidia_driver_ubuntu_cuda_package: "cuda-drivers-{{ nvidia_driver_ubuntu_branch }}"

--- a/files/cuda-ubuntu.pin
+++ b/files/cuda-ubuntu.pin
@@ -1,3 +1,0 @@
-Package: *
-Pin: release l=NVIDIA CUDA
-Pin-Priority: 600

--- a/tasks/install-ubuntu-cuda-repo.yml
+++ b/tasks/install-ubuntu-cuda-repo.yml
@@ -4,23 +4,26 @@
     repo: ppa:graphics-drivers/ppa
     state: absent
 
-- name: add pin file
-  copy:
-    src: "cuda-ubuntu.pin"
-    dest: "/etc/apt/preferences.d/cuda-repository-pin-600"
-    owner: "root"
-    group: "root"
-    mode: "0644"
-  when: nvidia_driver_add_repos | bool
-
-- name: add key
+- name: remove old signing key
   apt_key:
-    url: "{{ nvidia_driver_ubuntu_cuda_repo_gpgkey_url }}"
-    id: "{{ nvidia_driver_ubuntu_cuda_repo_gpgkey_id }}"
+    id: "{{ old_nvidia_driver_ubuntu_cuda_repo_gpgkey_id }}"
+    state: absent
   environment: "{{proxy_env if proxy_env is defined else {}}}"
   when: nvidia_driver_add_repos | bool
 
-- name: esure kmod is installed
+- name: add CUDA keyring
+  apt:
+    deb: "{{ nvidia_driver_ubuntu_cuda_keyring_url }}"
+    state: "present"
+  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  when: nvidia_driver_add_repos | bool
+
+- name: force an apt update
+  apt:
+    update_cache: true
+  changed_when: false
+
+- name: ensure kmod is installed
   apt:
     name: "kmod"
     state: "present"
@@ -29,13 +32,6 @@
   kernel_blacklist:
     name: nouveau
     state: present
-
-- name: add repo
-  apt_repository:
-    repo: "deb {{ nvidia_driver_ubuntu_cuda_repo_baseurl }} /"
-    update_cache: yes
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
-  when: nvidia_driver_add_repos | bool
 
 - name: install driver packages
   apt:


### PR DESCRIPTION
Repository signing keys have changed, so we need to update the automation to match. https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/

Test plan: Passing CI tests