### PR TITLE
Install latest driver version on RHEL by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,8 +16,6 @@ epel_repo_key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansibl
 nvidia_driver_rhel_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"
 nvidia_driver_rhel_cuda_repo_gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/D42D0685.pub"
 
-nvidia_driver_rhel_branch: "{{ nvidia_driver_branch }}"
-
 
 ##############################################################################
 # Ubuntu                                                                     #

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -65,7 +65,7 @@
 
 - name: install driver packages RHEL/CentOS 7 and older
   yum:
-    name: "{{ nvidia_driver_package_version | ternary('nvidia-driver-latest-dkms-'+nvidia_driver_package_version, 'nvidia-driver-branch-'+nvidia_driver_rhel_branch) }}"
+    name: "{{ (nvidia_driver_package_version | length == 0) | ternary('nvidia-driver-latest-dkms', 'nvidia-driver-branch-'+nvidia_driver_package_version) }}"
     state: "{{ nvidia_driver_package_state }}"
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
   register: install_driver_rhel7
@@ -74,7 +74,7 @@
 
 - name: install driver packages RHEL/CentOS 8 and newer
   dnf:
-    name: "{{ nvidia_driver_package_version | ternary('@nvidia-driver:'+nvidia_driver_package_version, '@nvidia-driver:'+nvidia_driver_rhel_branch+'-dkms') }}"
+    name: "{{ (nvidia_driver_package_version | length == 0) | ternary('@nvidia-driver', '@nvidia-driver:'+nvidia_driver_package_version) }}"
     state: "{{ nvidia_driver_package_state }}"
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
   register: install_driver_rhel8


### PR DESCRIPTION
The role was not installing latest driver version by default on RHEL systems. With this change the latest driver is installed unless a specific version is selected using var `nvidia_driver_package_version`

One of the reasons was that there is no yum package named `nvidia-driver-latest-dkms-'+nvidia_driver_package_version`

After applying this patch it's not clear for me why there are two vars `nvidia_driver_package_version` and `nvidia_driver_branch`. I guess using a single var should work fine and be simpler isn't it?