### PR TITLE
Force installation of CUDA keyring in order to work around package version issue

### DIFF
--- a/tasks/install-ubuntu-cuda-repo.yml
+++ b/tasks/install-ubuntu-cuda-repo.yml
@@ -15,6 +15,7 @@
   apt:
     deb: "{{ nvidia_driver_ubuntu_cuda_keyring_url }}"
     state: "present"
+    force: true
   environment: "{{proxy_env if proxy_env is defined else {}}}"
   when: nvidia_driver_add_repos | bool
 


### PR DESCRIPTION
When re-running this role against Ubuntu 22.04 with the CUDA version of packages being installed, the following issue consistently occurs:

```
TASK [nvidia.nvidia_driver : add CUDA keyring] ********************************************************************************************************************************************************************
fatal: [10.1.10.28]: FAILED! => {"changed": false, "msg": "A later version is already installed"}
```

This is a simple patch that forces the CUDA keyring package to install even if there is a newer version of it installed or some other versioning conflict.