### PR TITLE
fix: Update role with ansible-lint recommendation

### DIFF
--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -1,89 +1,90 @@
 ---
 # We have to do this because the CentOS mirrors don't keep kernel-headers, etc
 # for older kernels.
-- name: ensure we have kernel-headers installed for the current kernel
+- name: Ensure we have kernel-headers installed for the current kernel
   block:
-  - name: attempt to install kernel support packages for current version
-    yum:
-      name:
-        - "kernel-headers-{{ ansible_kernel }}"
-        - "kernel-tools-{{ ansible_kernel }}"
-        - "kernel-tools-libs-{{ ansible_kernel }}"
-        - "kernel-devel-{{ ansible_kernel }}"
-        - "kernel-debug-devel-{{ ansible_kernel }}"
-      state: present
-    environment: "{{proxy_env if proxy_env is defined else {}}}"
+    - name: Attempt to install kernel support packages for current version
+      ansible.builtin.yum:
+        name:
+          - "kernel-headers-{{ ansible_kernel }}"
+          - "kernel-tools-{{ ansible_kernel }}"
+          - "kernel-tools-libs-{{ ansible_kernel }}"
+          - "kernel-devel-{{ ansible_kernel }}"
+          - "kernel-debug-devel-{{ ansible_kernel }}"
+        state: present
+      environment: "{{ proxy_env if proxy_env is defined else {} }}"
   rescue:
-  - name: update the kernel to latest version so we have a supported version
-    yum:
-      name:
-        - "kernel"
-        - "kernel-headers"
-        - "kernel-tools"
-        - "kernel-tools-libs"
-        - "kernel-devel"
-        - "kernel-debug-devel"
-      state: latest
-    environment: "{{proxy_env if proxy_env is defined else {}}}"
-  - name: reboot to pick up the new kernel
-    reboot:
-    when: not nvidia_driver_skip_reboot
+    - name: Update the kernel to latest version so we have a supported version
+      ansible.builtin.yum:
+        name:
+          - "kernel"
+          - "kernel-headers"
+          - "kernel-tools"
+          - "kernel-tools-libs"
+          - "kernel-devel"
+          - "kernel-debug-devel"
+        state: latest
+      environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
-- name: add epel repo gpg key
-  rpm_key:
+    - name: Reboot to pick up the new kernel
+      ansible.builtin.reboot:
+      when: not nvidia_driver_skip_reboot
+
+- name: Add epel repo gpg key
+  ansible.builtin.rpm_key:
     key: "{{ epel_repo_key }}"
     state: present
   when: nvidia_driver_add_repos | bool
 
-- name: add epel repo
+- name: Add epel repo
   become: true
-  yum:
+  ansible.builtin.yum:
     name:
       - "{{ epel_package }}"
     state: latest
   environment: "{{proxy_env if proxy_env is defined else {}}}"
   when: nvidia_driver_add_repos | bool
 
-- name: install dependencies
-  yum:
+- name: Install dependencies
+  ansible.builtin.yum:
     name: dkms
     state: present
 
-- name: blacklist nouveau
-  kernel_blacklist:
+- name: Blacklist nouveau
+  community.general.kernel_blacklist:
     name: nouveau
     state: present
 
-- name: add repo
-  yum_repository:
+- name: Add repo
+  ansible.builtin.yum_repository:
     name: cuda
     description: NVIDIA CUDA YUM Repo
     baseurl: "{{ nvidia_driver_rhel_cuda_repo_baseurl }}"
     gpgkey: "{{ nvidia_driver_rhel_cuda_repo_gpgkey }}"
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
   when: nvidia_driver_add_repos | bool
 
-- name: install driver packages RHEL/CentOS 7 and older
-  yum:
-    name: "{{ nvidia_driver_package_version | ternary('nvidia-driver-latest-dkms-'+nvidia_driver_package_version, 'nvidia-driver-branch-'+nvidia_driver_rhel_branch) }}"
+- name: Install driver packages RHEL/CentOS 7 and older
+  ansible.builtin.yum:
+    name: "{{ nvidia_driver_package_version | ternary('nvidia-driver-latest-dkms-' + nvidia_driver_package_version, 'nvidia-driver-branch-' + nvidia_driver_rhel_branch) }}"
     state: "{{ nvidia_driver_package_state }}"
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
   register: install_driver_rhel7
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
   when: ansible_distribution_major_version < '8'
 
-- name: install driver packages RHEL/CentOS 8 and newer
-  dnf:
-    name: "{{ nvidia_driver_package_version | ternary('@nvidia-driver:'+nvidia_driver_package_version, '@nvidia-driver:'+nvidia_driver_rhel_branch+'-dkms') }}"
+- name: Install driver packages RHEL/CentOS 8 and newer
+  ansible.builtin.dnf:
+    name: "{{ nvidia_driver_package_version | ternary('@nvidia-driver:' + nvidia_driver_package_version, '@nvidia-driver:' + nvidia_driver_rhel_branch + '-dkms') }}"
     state: "{{ nvidia_driver_package_state }}"
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
   register: install_driver_rhel8
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
   when: ansible_distribution_major_version > '7'
 
 - name: Set install_driver.changed var for RHEL 7/8
-  debug:
-      msg: Driver installed for RHEL
+  ansible.builtin.debug:
+    msg: Driver installed for RHEL
   when: install_driver_rhel7.changed or install_driver_rhel8.changed
   register: install_driver
   changed_when: install_driver_rhel7.changed or install_driver_rhel8.changed

--- a/tasks/install-ubuntu-cuda-repo.yml
+++ b/tasks/install-ubuntu-cuda-repo.yml
@@ -1,43 +1,43 @@
 ---
-- name: remove ppa
-  apt_repository:
+- name: Remove ppa
+  ansible.builtin.apt_repository:
     repo: ppa:graphics-drivers/ppa
     state: absent
 
-- name: remove old signing key
-  apt_key:
+- name: Remove old signing key
+  ansible.builtin.apt_key:
     id: "{{ old_nvidia_driver_ubuntu_cuda_repo_gpgkey_id }}"
     state: absent
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
   when: nvidia_driver_add_repos | bool
 
-- name: add CUDA keyring
-  apt:
+- name: Add CUDA keyring
+  ansible.builtin.apt:
     deb: "{{ nvidia_driver_ubuntu_cuda_keyring_url }}"
     state: "present"
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
   when: nvidia_driver_add_repos | bool
 
-- name: force an apt update
-  apt:
+- name: Force an apt update
+  ansible.builtin.apt:
     update_cache: true
   changed_when: false
 
-- name: ensure kmod is installed
-  apt:
+- name: Ensure kmod is installed
+  ansible.builtin.apt:
     name: "kmod"
     state: "present"
 
-- name: blacklist nouveau
-  kernel_blacklist:
+- name: Blacklist nouveau
+  community.general.kernel_blacklist:
     name: nouveau
     state: present
 
-- name: install driver packages
-  apt:
-    name: "{{ nvidia_driver_package_version | ternary(nvidia_driver_ubuntu_cuda_package+'='+nvidia_driver_package_version, nvidia_driver_ubuntu_cuda_package) }}"
+- name: Install driver packages
+  ansible.builtin.apt:
+    name: "{{ nvidia_driver_package_version | ternary(nvidia_driver_ubuntu_cuda_package + '=' + nvidia_driver_package_version, nvidia_driver_ubuntu_cuda_package) }}"
     state: "{{ nvidia_driver_package_state }}"
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
     purge: "{{ nvidia_driver_package_state == 'absent' }}"
   register: install_driver
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"

--- a/tasks/install-ubuntu.yml
+++ b/tasks/install-ubuntu.yml
@@ -1,15 +1,16 @@
 ---
-- name: remove ppa
-  apt_repository:
+- name: Remove ppa
+  ansible.builtin.apt_repository:
     repo: ppa:graphics-drivers/ppa
     state: absent
 
-- name: install driver packages
-  apt:
-    name: "{{ nvidia_driver_package_version | ternary(item+'='+nvidia_driver_package_version, item) }}"
+- name: Install driver packages
+  ansible.builtin.apt:
+    name: "{{ nvidia_driver_package_version | ternary(item + '=' + nvidia_driver_package_version, item) }}"
     state: "{{ nvidia_driver_package_state }}"
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
     purge: "{{ nvidia_driver_package_state == 'absent' }}"
   loop: "{{ nvidia_driver_ubuntu_packages }}"
   register: install_driver
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
+  become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,52 +1,61 @@
 ---
-- name: unload nouveau
-  modprobe:
+- name: Unload nouveau
+  community.general.modprobe:
     name: nouveau
     state: absent
   ignore_errors: true
+  become: true
 
-- name: ubuntu install tasks (canonical repos)
-  include_tasks: install-ubuntu.yml
+- name: Blacklist the nouveau driver module
+  community.general.kernel_blacklist:
+    name: nouveau
+    state: present
+  become: true
+
+- name: Ubuntu install tasks (canonical repos)
+  ansible.builtin.include_tasks: install-ubuntu.yml
   when: ansible_distribution == 'Ubuntu' and (not nvidia_driver_ubuntu_install_from_cuda_repo)
 
-- name: ubuntu install tasks (CUDA repo)
-  include_tasks: install-ubuntu-cuda-repo.yml
+- name: Ubuntu install tasks (CUDA repo)
+  ansible.builtin.include_tasks: install-ubuntu-cuda-repo.yml
   when: ansible_distribution == 'Ubuntu' and nvidia_driver_ubuntu_install_from_cuda_repo
 
-- name: redhat family install tasks
-  include_tasks: install-redhat.yml
+- name: RedHat family install tasks
+  ansible.builtin.include_tasks: install-redhat.yml
   when: ansible_os_family == 'RedHat'
 
-- name: create persistenced override dir
-  file:
+- name: Create persistenced override dir
+  ansible.builtin.file:
     path: /etc/systemd/system/nvidia-persistenced.service.d/
     state: directory
-    recurse: yes
+    recurse: true
 
-- name: configure persistenced service to turn on persistence mode
-  copy:
+- name: Configure persistenced service to turn on persistence mode
+  ansible.builtin.copy:
     src: nvidia-persistenced-override.conf
     dest: /etc/systemd/system/nvidia-persistenced.service.d/override.conf
+    mode: "0644"
   when: nvidia_driver_persistence_mode_on
 
-- name: remove persistenced service override
-  file:
+- name: Remove persistenced service override
+  ansible.builtin.file:
     path: /etc/systemd/system/nvidia-persistenced.service.d/override.conf
     state: absent
   when: not nvidia_driver_persistence_mode_on
 
-- name: enable persistenced
-  systemd:
+- name: Enable persistenced
+  ansible.builtin.systemd:
     name: nvidia-persistenced
-    enabled: yes
+    enabled: true
   when: nvidia_driver_package_state != 'absent'
 
-- name: set module parameters
-  template:
+- name: Set module parameters
+  ansible.builtin.template:
     src: nvidia.conf.j2
     dest: "{{ nvidia_driver_module_file }}"
     mode: '0644'
 
-- name: reboot after driver install
-  reboot:
+- name: Reboot after driver install
+  ansible.builtin.reboot:
+  become: true
   when: install_driver.changed and not nvidia_driver_skip_reboot


### PR DESCRIPTION
This change includes a few minor changes.

- Use ansible FQCN names over short names
- Added `become: true` on specific modules that required privilege. (Make it clear which module needs privilege escalation.) 
- Add Nouveau driver module to blacklist on Ubuntu when installed without Cuda repo
- for `modprobe` i used `community.general.modprobe` as it is recommended by Ansible Lint (_You should use canonical module name `community.general.modprobe` instead of `ansible.builtin.modprobe`._ )