### PR TITLE
updated persistenced mode using nvidia-smi

### DIFF
--- a/files/nvidia-persistenced-override.conf
+++ b/files/nvidia-persistenced-override.conf
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/bin/nvidia-persistenced --user root --persistence-mode --verbose
+ExecStart=/usr/bin/nvidia-smi --persistence-mode=1 


### PR DESCRIPTION
According to the [Documentation](https://docs.nvidia.com/deploy/driver-persistence/index.html#persistence-daemon%5B/url%5D), the persistenced mode is set with `nvidia-smi` now. 
