### PR TITLE
aarch64: use `sbsa` as the architecture for aarch64

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
-_ubuntu_repo_dir: "{{ ansible_distribution | lower }}{{ ansible_distribution_version | replace('.', '') }}/{{ ansible_architecture }}"
-_rhel_repo_dir: "rhel{{ ansible_distribution_major_version }}/{{ ansible_architecture }}"
+_ubuntu_repo_dir: "{{ ansible_distribution | lower }}{{ ansible_distribution_version | replace('.', '') }}/{{ ansible_architecture | replace('aarch64', 'sbsa') }}"
+_rhel_repo_dir: "rhel{{ ansible_distribution_major_version }}/{{ ansible_architecture | replace('aarch64', 'sbsa') }}"


### PR DESCRIPTION
NVidia's name for aarch64 is "sbsa" is a term used for server-grade
hardware to distinguish it from any random aarch64 hardware.

Signed-off-by: Ben Boeckel <ben.boeckel@kitware.com>