### PR TITLE
ansible: migrate to `ansible_facts` instead of top-level variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ ansible-galaxy install nvidia.nvidia_driver
 
 | Variable                               | Default value                                                                                                     | Description                       |
 |----------------------------------------|-------------------------------------------------------------------------------------------------------------------|-----------------------------------|
-| `epel_package`                         | `"https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"` | Package to install to enable EPEL |
+| `epel_package`                         | `"https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm"` | Package to install to enable EPEL |
 | `nvidia_driver_rhel_cuda_repo_baseurl` | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"`                                | Base URL to use for CUDA repo     |
 | `nvidia_driver_rhel_cuda_repo_gpgkey`  | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/7fa2af80.pub"`                    | GPG key for the CUDA repo         |
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,8 +11,8 @@ nvidia_driver_branch: "515"
 ##############################################################################
 # RedHat family                                                              #
 ##############################################################################
-epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_repo_key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm"
+epel_repo_key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_facts['distribution_major_version'] }}"
 nvidia_driver_rhel_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"
 nvidia_driver_rhel_cuda_repo_gpgkey: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/D42D0685.pub"
 

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -6,11 +6,11 @@
   - name: attempt to install kernel support packages for current version
     yum:
       name:
-        - "kernel-headers-{{ ansible_kernel }}"
-        - "kernel-tools-{{ ansible_kernel }}"
-        - "kernel-tools-libs-{{ ansible_kernel }}"
-        - "kernel-devel-{{ ansible_kernel }}"
-        - "kernel-debug-devel-{{ ansible_kernel }}"
+        - "kernel-headers-{{ ansible_facts['kernel'] }}"
+        - "kernel-tools-{{ ansible_facts['kernel'] }}"
+        - "kernel-tools-libs-{{ ansible_facts['kernel'] }}"
+        - "kernel-devel-{{ ansible_facts['kernel'] }}"
+        - "kernel-debug-devel-{{ ansible_facts['kernel'] }}"
       state: present
     environment: "{{proxy_env if proxy_env is defined else {}}}"
   rescue:
@@ -70,7 +70,7 @@
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
   register: install_driver_rhel7
   environment: "{{proxy_env if proxy_env is defined else {}}}"
-  when: ansible_distribution_major_version < '8'
+  when: ansible_facts['distribution_major_version'] < '8'
 
 - name: install driver packages RHEL/CentOS 8 and newer
   dnf:
@@ -79,7 +79,7 @@
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
   register: install_driver_rhel8
   environment: "{{proxy_env if proxy_env is defined else {}}}"
-  when: ansible_distribution_major_version > '7'
+  when: ansible_facts['distribution_major_version'] > '7'
 
 - name: Set install_driver.changed var for RHEL 7/8
   debug:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,15 +7,15 @@
 
 - name: ubuntu install tasks (canonical repos)
   include_tasks: install-ubuntu.yml
-  when: ansible_distribution == 'Ubuntu' and (not nvidia_driver_ubuntu_install_from_cuda_repo)
+  when: ansible_facts['distribution'] == 'Ubuntu' and (not nvidia_driver_ubuntu_install_from_cuda_repo)
 
 - name: ubuntu install tasks (CUDA repo)
   include_tasks: install-ubuntu-cuda-repo.yml
-  when: ansible_distribution == 'Ubuntu' and nvidia_driver_ubuntu_install_from_cuda_repo
+  when: ansible_facts['distribution'] == 'Ubuntu' and nvidia_driver_ubuntu_install_from_cuda_repo
 
 - name: redhat family install tasks
   include_tasks: install-redhat.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: create persistenced override dir
   file:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
-_ubuntu_repo_dir: "{{ ansible_distribution | lower }}{{ ansible_distribution_version | replace('.', '') }}/{{ ansible_architecture | replace('aarch64', 'sbsa') }}"
-_rhel_repo_dir: "rhel{{ ansible_distribution_major_version }}/{{ ansible_architecture | replace('aarch64', 'sbsa') }}"
+_ubuntu_repo_dir: "{{ ansible_facts['distribution'] | lower }}{{ ansible_facts['distribution_version'] | replace('.', '') }}/{{ ansible_facts['architecture'] | replace('aarch64', 'sbsa') }}"
+_rhel_repo_dir: "rhel{{ ansible_facts['distribution_major_version'] }}/{{ ansible_facts['architecture'] | replace('aarch64', 'sbsa') }}"


### PR DESCRIPTION
Ansible will stop providing them in the future.