### PR TITLE
fix(redhat): compare distribution major version as integer

### DIFF
--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -70,7 +70,7 @@
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
   register: install_driver_rhel7
   environment: "{{proxy_env if proxy_env is defined else {}}}"
-  when: ansible_distribution_major_version < '8'
+  when: ansible_distribution_major_version | int < 8
 
 - name: install driver packages RHEL/CentOS 8 and newer
   dnf:
@@ -79,7 +79,7 @@
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
   register: install_driver_rhel8
   environment: "{{proxy_env if proxy_env is defined else {}}}"
-  when: ansible_distribution_major_version > '7'
+  when: ansible_distribution_major_version | int > 7
 
 - name: Set install_driver.changed var for RHEL 7/8
   debug:

--- a/tests/test_rhel_version_comparison.py
+++ b/tests/test_rhel_version_comparison.py
@@ -1,0 +1,67 @@
+"""Regression test: RHEL major-version comparisons in tasks/install-redhat.yml.
+
+Bug: the version-gated `when` conditions compared the string fact
+`ansible_distribution_major_version` against string literals, so Jinja
+performed a lexicographic comparison. For major version '10',
+`'10' < '8'` is True and `'10' > '7'` is False, which would run the
+legacy RHEL-7 yum task and skip the modern dnf task.
+
+Fix: cast the fact with `| int` before comparing.
+
+This test extracts the two version-gated `when` expressions from the
+tasks file and evaluates them with Jinja2 (the same engine Ansible
+uses) for major versions 7/8/9/10, asserting that EL10 selects the
+RHEL-8 (dnf) path.
+
+Run: uv run --with pytest --with jinja2 --with pyyaml pytest tests/test_rhel_version_comparison.py
+"""
+
+from pathlib import Path
+
+import jinja2
+import pytest
+import yaml
+
+TASKS_FILE = Path(__file__).resolve().parent.parent / "tasks" / "install-redhat.yml"
+
+# (version, expect_el7_task, expect_el8_task)
+EXPECTED = [
+    ("7", True, False),
+    ("8", False, True),
+    ("9", False, True),
+    ("10", False, True),  # the case the string comparison got wrong
+]
+
+
+def _version_conditions():
+    """Return (el7_when, el8_when) expressions from the tasks file."""
+    tasks = yaml.safe_load(TASKS_FILE.read_text())
+    conditions = []
+    for task in tasks:
+        when = task.get("when")
+        if isinstance(when, str) and "ansible_distribution_major_version" in when:
+            conditions.append(when)
+    assert len(conditions) == 2, (
+        f"expected 2 version-gated when conditions, found {conditions!r}"
+    )
+    return conditions
+
+
+@pytest.mark.parametrize("version,expect_el7,expect_el8", EXPECTED)
+def test_driver_install_task_selection(version, expect_el7, expect_el8):
+    el7_when, el8_when = _version_conditions()
+    env = jinja2.Environment()
+    run_el7 = env.compile_expression(el7_when)(
+        ansible_distribution_major_version=version
+    )
+    run_el8 = env.compile_expression(el8_when)(
+        ansible_distribution_major_version=version
+    )
+    assert bool(run_el7) is expect_el7, (
+        f"EL{version}: legacy yum task condition {el7_when!r} "
+        f"evaluated to {run_el7}, expected {expect_el7}"
+    )
+    assert bool(run_el8) is expect_el8, (
+        f"EL{version}: modern dnf task condition {el8_when!r} "
+        f"evaluated to {run_el8}, expected {expect_el8}"
+    )


### PR DESCRIPTION
## Summary

On RHEL-family hosts, the role picks one of two driver-install tasks based on `ansible_distribution_major_version`. The version conditions compared the fact (a string) against string literals, which is a lexicographic comparison. For a hypothetical major version `10` (RHEL/Rocky/Alma 10), `'10' < '8'` is `True` and `'10' > '7'` is `False`, so the role would run the legacy RHEL-7 `yum` task and skip the modern `dnf` module task — installing the wrong package name through the wrong package manager.

## Root cause

```yaml
when: ansible_distribution_major_version < '8'   # '10' < '8' -> True
...
when: ansible_distribution_major_version > '7'   # '10' > '7' -> False
```

`ansible_distribution_major_version` is a string, so Jinja performs string ordering:

| version | old `< '8'` | old `> '7'` | correct |
|---------|-------------|-------------|---------|
| 7       | True        | False       | ok      |
| 8, 9    | False       | True        | ok      |
| 10      | True        | False       | inverted|

## Fix

Cast the fact to an integer before comparing:

```yaml
when: ansible_distribution_major_version | int < 8
...
when: ansible_distribution_major_version | int > 7
```

## Testing

No local GPU/host to run the full molecule suite (docker + systemd images, driver installs); CI covers that. Verified locally with:

- `python3 -c yaml.safe_load(...)` — YAML parses.
- `uv run --with ansible ansible-playbook --syntax-check` on a playbook including `tasks/install-redhat.yml` — passes.
- `uv run --with ansible --with jinja2` evaluating both the old and new `when` expressions for versions 7/8/9/10:
  - 7, 8, 9: identical results before and after the fix (no behavior change for supported releases).
  - 10: old expressions select the RHEL-7 task and skip the RHEL-8 task; new expressions select the RHEL-8 task and skip the RHEL-7 task.

## Why existing tests missed it

Molecule only tests CentOS 7 and Ubuntu images (the CentOS 8 platform is commented out), so a double-digit EL major version is never exercised, and the Jinja string comparison happens to work for all single-digit versions.