### PR TITLE
ci: repair the Molecule workflow

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install Molecule
         run: pip install --upgrade ansible-core molecule 'molecule-plugins[docker]' docker
 
+      - name: Install collection dependencies
+        run: ansible-galaxy collection install -r ansible-role-nvidia-driver/requirements.yml
+
       - name: Run Molecule
         run: molecule test
         working-directory: ansible-role-nvidia-driver

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -1,15 +1,33 @@
 ---
+name: molecule
+
 on:
   - push
   - pull_request
 
 jobs:
-  build:
-    runs-on: ubuntu-20.04
+  molecule:
+    runs-on: ubuntu-latest
     steps:
-      - name: checkout
-        uses: actions/checkout@v2
+      - name: Check out the role
+        uses: actions/checkout@v4
         with:
-          path: "${{ github.repository }}"
-      - name: molecule
-        uses: robertdebock/molecule-action@2.7.2
+          # Molecule resolves the role through the parent of the project
+          # directory, so the checkout directory must match the role name
+          # used by molecule/default/converge.yml.
+          path: ansible-role-nvidia-driver
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Molecule
+        run: pip install --upgrade ansible-core molecule 'molecule-plugins[docker]' docker
+
+      - name: Run Molecule
+        run: molecule test
+        working-directory: ansible-role-nvidia-driver
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -29,5 +29,8 @@ jobs:
         run: molecule test
         working-directory: ansible-role-nvidia-driver
         env:
+          # converge.yml includes the role by name, so the directory holding
+          # the checkout must be on the roles path.
+          ANSIBLE_ROLES_PATH: ${{ github.workspace }}
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -2,15 +2,17 @@
 name: molecule
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   molecule:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the role
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Molecule resolves the role through the parent of the project
           # directory, so the checkout directory must match the role name
@@ -18,15 +20,24 @@ jobs:
           path: ansible-role-nvidia-driver
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
-      - name: Install Molecule
-        run: pip install --upgrade ansible-core molecule 'molecule-plugins[docker]' docker
+      - name: Install test tooling
+        run: pip install --upgrade ansible-core molecule 'molecule-plugins[docker]' docker pytest jinja2 pyyaml
 
       - name: Install collection dependencies
         run: ansible-galaxy collection install -r ansible-role-nvidia-driver/requirements.yml
+
+      - name: Run Python tests
+        working-directory: ansible-role-nvidia-driver
+        run: |
+          if find tests -type f -name 'test_*.py' -print -quit | grep -q .; then
+            python -m pytest tests
+          else
+            echo "No Python unit tests found."
+          fi
 
       - name: Run Molecule
         run: molecule test

--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ By default, the Canonical repositories will be used, and the driver installed wi
   - nvidia.nvidia_driver
 ```
 
+## Requirements
+
+This role uses modules from the `community.general` collection, which is not
+part of `ansible-core`. When installing the role from Galaxy, install the
+collection explicitly:
+
+```
+ansible-galaxy collection install community.general
+```
+
+For a source checkout, `ansible-galaxy collection install -r requirements.yml`
+installs the declared collection dependencies.
+
 ## Supported distributions
 
 Currently exercised by Molecule's container CI:

--- a/README.md
+++ b/README.md
@@ -65,13 +65,26 @@ By default, the Canonical repositories will be used, and the driver installed wi
 
 ## Supported distributions
 
-Currently, this role supports the following Linux distributions:
+Currently exercised by Molecule's container CI:
 
-* NVIDIA DGX OS 4
-* NVIDIA DGX OS 5
-* Ubuntu 18.04 LTS
-* Ubuntu 20.04 LTS
-* CentOS 7
-* Red Hat Enterprise Linux 7
+* Ubuntu 22.04 LTS
+* Ubuntu 24.04 LTS
+* Rocky Linux 8
+* Rocky Linux 9
+
+Red Hat Enterprise Linux 8 and 9 use the same Red Hat-family role path and
+NVIDIA repositories as the Rocky Linux scenarios, but RHEL itself is not
+directly exercised in CI.
+
+NVIDIA DGX OS 6 and DGX OS 7 are based on Ubuntu 22.04 and Ubuntu 24.04
+respectively. They share the Ubuntu role paths, but DGX OS and physical DGX
+hardware are not directly exercised in CI.
+
+The role retains legacy code paths for the following. They are not exercised
+in CI and receive best-effort, community support; users should verify
+repository and driver availability for their target release.
+
+* NVIDIA DGX OS 4 / DGX OS 5
+* Ubuntu 18.04 LTS / Ubuntu 20.04 LTS
+* CentOS 7 / Red Hat Enterprise Linux 7
 * CentOS 8
-* Red Hat Enterprise Linux 8

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ By default, the Canonical repositories will be used, and the driver installed wi
   - nvidia.nvidia_driver
 ```
 
-## Requirements
+## Ansible collection dependency
 
 This role uses modules from the `community.general` collection, which is not
 part of `ansible-core`. When installing the role from Galaxy, install the

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ ansible-galaxy install nvidia.nvidia_driver
 | `nvidia_driver_skip_reboot`         | `no`                            | Whether to skip rebooting the node during the install                                                                 |
 | `nvidia_driver_module_file`         | `"/etc/modprobe.d/nvidia.conf"` | Filename to use for NVIDIA driver parameters                                                                          |
 | `nvidia_driver_module_params`       | `""`                            | Parameters to pass to the NVIDIA driver                                                                               |
-| `nvidia_driver_branch`              | `"515"`                         | Default driver branch to install                                                                                      |
+| `nvidia_driver_branch`              | `"580"`                         | Default driver branch to install                                                                                      |
 
 ### Red Hat specific variables
 
@@ -40,7 +40,8 @@ $ ansible-galaxy install nvidia.nvidia_driver
 |----------------------------------------|-------------------------------------------------------------------------------------------------------------------|-----------------------------------|
 | `epel_package`                         | `"https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"` | Package to install to enable EPEL |
 | `nvidia_driver_rhel_cuda_repo_baseurl` | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"`                                | Base URL to use for CUDA repo     |
-| `nvidia_driver_rhel_cuda_repo_gpgkey`  | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/7fa2af80.pub"`                    | GPG key for the CUDA repo         |
+| `nvidia_driver_rhel_cuda_repo_gpgkey`  | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/D42D0685.pub"`                    | GPG key for the CUDA repo         |
+| `nvidia_driver_rhel_branch`            | `"{{ nvidia_driver_branch }}"`                                                                                    | Driver branch on Red Hat family hosts |
 
 ### Ubuntu specific variables
 
@@ -50,10 +51,17 @@ By default, the Canonical repositories will be used, and the driver installed wi
 
 | Variable                                      | Default value                                                                      | Description                                          |
 |-----------------------------------------------|------------------------------------------------------------------------------------|------------------------------------------------------|
+| `nvidia_driver_ubuntu_branch`                 | `"{{ nvidia_driver_branch }}"`                                                     | Driver branch on Ubuntu hosts                        |
 | `nvidia_driver_ubuntu_install_from_cuda_repo` | `no`                                                                               | Flag whether to use the CUDA repo                    |
-| `nvidia_driver_ubuntu_cuda_repo_baseurl`      | `"http://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"` | Base URL to use for CUDA repo                        |
-| `nvidia_driver_ubuntu_cuda_package`           | `"cuda-drivers"`                                                                   | Package name to install from CUDA repo               |
+| `nvidia_driver_ubuntu_cuda_repo_baseurl`      | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"` | Base URL to use for CUDA repo                       |
+| `nvidia_driver_ubuntu_cuda_package`           | `"cuda-drivers-{{ nvidia_driver_ubuntu_branch }}"`                                  | Package name to install from CUDA repo              |
 | `nvidia_driver_ubuntu_packages_suffix`        | `"-server"`                                                                        | The suffix added to the apt packages when installing |
+
+On Ubuntu, the driver branch is part of the package name. If
+`nvidia_driver_package_version` pins a version from an older branch, also set
+`nvidia_driver_ubuntu_branch` (or `nvidia_driver_branch`) to that matching
+branch. A version-only pin otherwise combines the new default package name with
+an incompatible older version.
 
 ## Example playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ nvidia_driver_skip_reboot: no
 nvidia_driver_module_file: /etc/modprobe.d/nvidia.conf
 nvidia_driver_module_params: ''
 nvidia_driver_add_repos: yes
-nvidia_driver_branch: "515"
+nvidia_driver_branch: "580"
 
 
 ##############################################################################

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,6 @@ nvidia_driver_ubuntu_packages:
 # Installing with CUDA repositories
 old_nvidia_driver_ubuntu_cuda_repo_gpgkey_id: "7fa2af80"
 nvidia_driver_ubuntu_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"
-nvidia_driver_ubuntu_cuda_keyring_package: "cuda-keyring_1.0-1_all.deb"
+nvidia_driver_ubuntu_cuda_keyring_package: "cuda-keyring_1.1-1_all.deb"
 nvidia_driver_ubuntu_cuda_keyring_url: "{{ nvidia_driver_ubuntu_cuda_repo_baseurl }}/{{ nvidia_driver_ubuntu_cuda_keyring_package }}"
 nvidia_driver_ubuntu_cuda_package: "cuda-drivers-{{ nvidia_driver_ubuntu_branch }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,13 +10,12 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - 'xenial'
-        - 'bionic'
-        - 'focal'
+        - 'jammy'
+        - 'noble'
     - name: EL
       versions:
-        - '7'
         - '8'
+        - '9'
 
   galaxy_tags:
     - 'nvidia'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -101,6 +101,12 @@ platforms:
 
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      # The container images do not provide a writable home for the
+      # connecting user, so Ansible cannot create its default remote
+      # temporary directory under ~/.ansible/tmp.
+      remote_tmp: /tmp/.ansible/tmp
   ansible_args:
   - -vv
   inventory:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -74,6 +74,8 @@ platforms:
     command: /sbin/init
     pre_build_image: true
     privileged: true
+    groups:
+    - el8
 
   - name: rockylinux-9
     image: geerlingguy/docker-rockylinux9-ansible
@@ -104,5 +106,10 @@ provisioner:
         nvidia_driver_ubuntu_packages_suffix: ""
       cuda_repo:
         nvidia_driver_ubuntu_install_from_cuda_repo: true
+      el8:
+        # The EL8 image ships only Python 3.6 as /usr/bin/python3, which is
+        # too old for current ansible-core modules. prepare.yml installs
+        # Python 3.9 and this points the interpreter at it.
+        ansible_python_interpreter: /usr/bin/python3.9
 verifier:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -103,12 +103,16 @@ provisioner:
     group_vars:
       all:
         nvidia_driver_skip_reboot: true
+        # Keep this CI-repair PR independently runnable while installable
+        # defaults are reviewed in the follow-up PRs.
+        nvidia_driver_branch: "580"
       canonical_repo:
         nvidia_driver_ubuntu_install_from_cuda_repo: false
       canonical_repo_noserver:
         nvidia_driver_ubuntu_packages_suffix: ""
       cuda_repo:
         nvidia_driver_ubuntu_install_from_cuda_repo: true
+        nvidia_driver_ubuntu_cuda_keyring_package: "cuda-keyring_1.1-1_all.deb"
       el:
         # The connection is already root and these images have no working
         # sudo ('PAM account management error'). Naming the user lets

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -112,7 +112,6 @@ provisioner:
         nvidia_driver_ubuntu_packages_suffix: ""
       cuda_repo:
         nvidia_driver_ubuntu_install_from_cuda_repo: true
-        nvidia_driver_ubuntu_cuda_keyring_package: "cuda-keyring_1.1-1_all.deb"
       el:
         # The connection is already root and these images have no working
         # sudo ('PAM account management error'). Naming the user lets

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -75,6 +75,7 @@ platforms:
     pre_build_image: true
     privileged: true
     groups:
+    - el
     - el8
 
   - name: rockylinux-9
@@ -85,6 +86,8 @@ platforms:
     command: /sbin/init
     pre_build_image: true
     privileged: true
+    groups:
+    - el
 
 provisioner:
   name: ansible
@@ -106,6 +109,11 @@ provisioner:
         nvidia_driver_ubuntu_packages_suffix: ""
       cuda_repo:
         nvidia_driver_ubuntu_install_from_cuda_repo: true
+      el:
+        # The connection is already root and these images have no working
+        # sudo ('PAM account management error'). Naming the user lets
+        # Ansible skip escalation instead of shelling out to sudo.
+        ansible_user: root
       el8:
         # The EL8 image ships only Python 3.6 as /usr/bin/python3, which is
         # too old for current ansible-core modules. prepare.yml installs

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,7 +8,8 @@ platforms:
   - name: ubuntu-2204-canonical
     image: geerlingguy/docker-ubuntu2204-ansible
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     command: /sbin/init
     pre_build_image: true
     privileged: true
@@ -19,7 +20,8 @@ platforms:
   - name: ubuntu-2204-canonical-noserver
     image: geerlingguy/docker-ubuntu2204-ansible
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     command: /sbin/init
     pre_build_image: true
     privileged: true
@@ -31,7 +33,8 @@ platforms:
   - name: ubuntu-2204-cuda
     image: geerlingguy/docker-ubuntu2204-ansible
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     command: /sbin/init
     pre_build_image: true
     privileged: true
@@ -42,7 +45,8 @@ platforms:
   - name: ubuntu-2404-canonical
     image: geerlingguy/docker-ubuntu2404-ansible
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     command: /sbin/init
     pre_build_image: true
     privileged: true
@@ -53,7 +57,8 @@ platforms:
   - name: ubuntu-2404-cuda
     image: geerlingguy/docker-ubuntu2404-ansible
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     command: /sbin/init
     pre_build_image: true
     privileged: true
@@ -64,7 +69,8 @@ platforms:
   - name: rockylinux-8
     image: geerlingguy/docker-rockylinux8-ansible
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     command: /sbin/init
     pre_build_image: true
     privileged: true
@@ -72,7 +78,8 @@ platforms:
   - name: rockylinux-9
     image: geerlingguy/docker-rockylinux9-ansible
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     command: /sbin/init
     pre_build_image: true
     privileged: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,62 +5,6 @@ driver:
   name: docker
 platforms:
 
-  - name: ubuntu-1804-canonical
-    image: geerlingguy/docker-ubuntu1804-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /sbin/init
-    pre_build_image: true
-    privileged: true
-    groups:
-    - canonical_repo
-    - ubuntu
-
-  - name: ubuntu-1804-cuda
-    image: geerlingguy/docker-ubuntu1804-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /sbin/init
-    pre_build_image: true
-    privileged: true
-    groups:
-    - cuda_repo
-    - ubuntu
-
-  - name: ubuntu-2004-canonical-server
-    image: geerlingguy/docker-ubuntu2004-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /sbin/init
-    pre_build_image: true
-    privileged: true
-    groups:
-    - canonical_repo
-    - ubuntu
-
-  - name: ubuntu-2004-canonical-noserver
-    image: geerlingguy/docker-ubuntu2004-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /sbin/init
-    pre_build_image: true
-    privileged: true
-    groups:
-    - canonical_repo
-    - canonical_repo_noserver
-    - ubuntu
-
-  - name: ubuntu-2004-cuda
-    image: geerlingguy/docker-ubuntu2004-ansible
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /sbin/init
-    pre_build_image: true
-    privileged: true
-    groups:
-    - cuda_repo
-    - ubuntu
-
   - name: ubuntu-2204-canonical
     image: geerlingguy/docker-ubuntu2204-ansible
     volumes:
@@ -70,6 +14,18 @@ platforms:
     privileged: true
     groups:
     - canonical_repo
+    - ubuntu
+
+  - name: ubuntu-2204-canonical-noserver
+    image: geerlingguy/docker-ubuntu2204-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    pre_build_image: true
+    privileged: true
+    groups:
+    - canonical_repo
+    - canonical_repo_noserver
     - ubuntu
 
   - name: ubuntu-2204-cuda
@@ -83,21 +39,43 @@ platforms:
     - cuda_repo
     - ubuntu
 
-  - name: centos-7
-    image: geerlingguy/docker-centos7-ansible
+  - name: ubuntu-2404-canonical
+    image: geerlingguy/docker-ubuntu2404-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    pre_build_image: true
+    privileged: true
+    groups:
+    - canonical_repo
+    - ubuntu
+
+  - name: ubuntu-2404-cuda
+    image: geerlingguy/docker-ubuntu2404-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    pre_build_image: true
+    privileged: true
+    groups:
+    - cuda_repo
+    - ubuntu
+
+  - name: rockylinux-8
+    image: geerlingguy/docker-rockylinux8-ansible
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /sbin/init
     pre_build_image: true
     privileged: true
 
-#  - name: centos-8
-#    image: geerlingguy/docker-centos8-ansible
-#    volumes:
-#      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-#    command: /sbin/init
-#    pre_build_image: true
-#    privileged: true
+  - name: rockylinux-9
+    image: geerlingguy/docker-rockylinux9-ansible
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /sbin/init
+    pre_build_image: true
+    privileged: true
 
 provisioner:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -103,9 +103,6 @@ provisioner:
     group_vars:
       all:
         nvidia_driver_skip_reboot: true
-        # Keep this CI-repair PR independently runnable while installable
-        # defaults are reviewed in the follow-up PRs.
-        nvidia_driver_branch: "580"
       canonical_repo:
         nvidia_driver_ubuntu_install_from_cuda_repo: false
       canonical_repo_noserver:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -11,9 +11,10 @@
 
 - hosts: el8
   # Facts cannot be gathered until a supported Python is present, and raw
-  # needs no Python at all.
+  # needs no Python at all. The container connection is already root, so
+  # become would invoke sudo needlessly — and the image has no usable sudo.
   gather_facts: false
-  become: true
+  become: false
   tasks:
 
   - name: install a Python supported by current ansible-core

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -9,14 +9,14 @@
       name: gpg-agent
       state: present
 
-- hosts: el8
+- name: Prepare EL8 hosts
+  hosts: el8
   # Facts cannot be gathered until a supported Python is present, and raw
   # needs no Python at all. The container connection is already root, so
   # become would invoke sudo needlessly — and the image has no usable sudo.
   gather_facts: false
   become: false
   tasks:
-
-  - name: install a Python supported by current ansible-core
-    raw: dnf install -y python39
-    changed_when: false
+    - name: Install a Python supported by current ansible-core
+      ansible.builtin.raw: dnf install -y python39
+      changed_when: false

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -8,3 +8,14 @@
       update_cache: yes
       name: gpg-agent
       state: present
+
+- hosts: el8
+  # Facts cannot be gathered until a supported Python is present, and raw
+  # needs no Python at all.
+  gather_facts: false
+  become: true
+  tasks:
+
+  - name: install a Python supported by current ansible-core
+    raw: dnf install -y python39
+    changed_when: false

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,8 @@
+---
+# The role uses modules from community.general (modprobe,
+# kernel_blacklist). ansible-core does not ship them, so install this
+# before running the role:
+#
+#   ansible-galaxy collection install -r requirements.yml
+collections:
+  - name: community.general


### PR DESCRIPTION
## Summary

Replace the retired Ubuntu 20.04 GitHub-hosted runner image with a current runner, modernize the Molecule harness, and align the documented support matrix with the platforms exercised by CI.

## Changes

- Run on `ubuntu-latest` with Python 3.12 and the current major releases of `actions/checkout` and `actions/setup-python`.
- Install Ansible, Molecule, the Docker plugin, Docker bindings, pytest, and the declared Galaxy collection dependencies explicitly.
- Check the role out at the path Molecule expects.
- Run standalone Python tests when a pull request contains them; skip that step successfully when none exist.
- Exercise:
  - Ubuntu 22.04: Canonical, Canonical no-server, and CUDA-repository paths
  - Ubuntu 24.04: Canonical and CUDA-repository paths
  - Rocky Linux 8 and 9
- Update the containers for cgroup v2, Ansible remote temporary directories, root execution on EL, and the EL8 Python 3.9 bootstrap.
- Align README and Galaxy metadata with the validated matrix. Older Ubuntu, DGX OS, EL7, and CentOS 8 paths remain community-supported rather than CI-validated.
- Restrict branch `push` runs to `master` so pull requests do not create duplicate workflow runs.

This CI-repair branch temporarily overrides its Molecule scenarios to driver branch 580 and CUDA keyring 1.1 so the workflow can run independently. Those shipped defaults are reviewed separately in #88 and #89. Each stacked pull request removes its corresponding test-only override so its check exercises the changed default.

## Current validation status

At head `ef5ac35`, the required Molecule check passed on the exact revision: [GitHub Actions run 30307979719](https://github.com/NVIDIA/ansible-role-nvidia-driver/actions/runs/30307979719).

Required merge order is **#87 → #88 → #89**. Before completing that sequence, require green checks against each exact head and the required independent approval.

Molecule's Docker scenarios validate role logic and package paths; they do not validate kernel-module operation, physical GPU enumeration, or `nvidia-smi`.

The conditional pytest step gives #86's RHEL version-comparison regression test a CI path once that pull request is refreshed against the repaired workflow.
