### PR TITLE
fix(ubuntu): bump pinned CUDA keyring to 1.1-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ ansible-galaxy install nvidia.nvidia_driver
 | `nvidia_driver_skip_reboot`         | `no`                            | Whether to skip rebooting the node during the install                                                                 |
 | `nvidia_driver_module_file`         | `"/etc/modprobe.d/nvidia.conf"` | Filename to use for NVIDIA driver parameters                                                                          |
 | `nvidia_driver_module_params`       | `""`                            | Parameters to pass to the NVIDIA driver                                                                               |
-| `nvidia_driver_branch`              | `"515"`                         | Default driver branch to install                                                                                      |
+| `nvidia_driver_branch`              | `"580"`                         | Default driver branch to install                                                                                      |
 
 ### Red Hat specific variables
 
@@ -40,7 +40,8 @@ $ ansible-galaxy install nvidia.nvidia_driver
 |----------------------------------------|-------------------------------------------------------------------------------------------------------------------|-----------------------------------|
 | `epel_package`                         | `"https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"` | Package to install to enable EPEL |
 | `nvidia_driver_rhel_cuda_repo_baseurl` | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"`                                | Base URL to use for CUDA repo     |
-| `nvidia_driver_rhel_cuda_repo_gpgkey`  | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/7fa2af80.pub"`                    | GPG key for the CUDA repo         |
+| `nvidia_driver_rhel_cuda_repo_gpgkey`  | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/D42D0685.pub"`                    | GPG key for the CUDA repo         |
+| `nvidia_driver_rhel_branch`            | `"{{ nvidia_driver_branch }}"`                                                                                    | Driver branch on Red Hat family hosts |
 
 ### Ubuntu specific variables
 
@@ -50,10 +51,17 @@ By default, the Canonical repositories will be used, and the driver installed wi
 
 | Variable                                      | Default value                                                                      | Description                                          |
 |-----------------------------------------------|------------------------------------------------------------------------------------|------------------------------------------------------|
+| `nvidia_driver_ubuntu_branch`                 | `"{{ nvidia_driver_branch }}"`                                                     | Driver branch on Ubuntu hosts                        |
 | `nvidia_driver_ubuntu_install_from_cuda_repo` | `no`                                                                               | Flag whether to use the CUDA repo                    |
-| `nvidia_driver_ubuntu_cuda_repo_baseurl`      | `"http://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"` | Base URL to use for CUDA repo                        |
-| `nvidia_driver_ubuntu_cuda_package`           | `"cuda-drivers"`                                                                   | Package name to install from CUDA repo               |
+| `nvidia_driver_ubuntu_cuda_repo_baseurl`      | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"` | Base URL to use for CUDA repo                       |
+| `nvidia_driver_ubuntu_cuda_package`           | `"cuda-drivers-{{ nvidia_driver_ubuntu_branch }}"`                                  | Package name to install from CUDA repo              |
 | `nvidia_driver_ubuntu_packages_suffix`        | `"-server"`                                                                        | The suffix added to the apt packages when installing |
+
+On Ubuntu, the driver branch is part of the package name. If
+`nvidia_driver_package_version` pins a version from an older branch, also set
+`nvidia_driver_ubuntu_branch` (or `nvidia_driver_branch`) to that matching
+branch. A version-only pin otherwise combines the new default package name with
+an incompatible older version.
 
 ## Example playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ nvidia_driver_skip_reboot: no
 nvidia_driver_module_file: /etc/modprobe.d/nvidia.conf
 nvidia_driver_module_params: ''
 nvidia_driver_add_repos: yes
-nvidia_driver_branch: "515"
+nvidia_driver_branch: "580"
 
 
 ##############################################################################

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,6 @@ nvidia_driver_ubuntu_packages:
 # Installing with CUDA repositories
 old_nvidia_driver_ubuntu_cuda_repo_gpgkey_id: "7fa2af80"
 nvidia_driver_ubuntu_cuda_repo_baseurl: "https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"
-nvidia_driver_ubuntu_cuda_keyring_package: "cuda-keyring_1.0-1_all.deb"
+nvidia_driver_ubuntu_cuda_keyring_package: "cuda-keyring_1.1-1_all.deb"
 nvidia_driver_ubuntu_cuda_keyring_url: "{{ nvidia_driver_ubuntu_cuda_repo_baseurl }}/{{ nvidia_driver_ubuntu_cuda_keyring_package }}"
 nvidia_driver_ubuntu_cuda_package: "cuda-drivers-{{ nvidia_driver_ubuntu_branch }}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -112,7 +112,6 @@ provisioner:
         nvidia_driver_ubuntu_packages_suffix: ""
       cuda_repo:
         nvidia_driver_ubuntu_install_from_cuda_repo: true
-        nvidia_driver_ubuntu_cuda_keyring_package: "cuda-keyring_1.1-1_all.deb"
       el:
         # The connection is already root and these images have no working
         # sudo ('PAM account management error'). Naming the user lets

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -103,9 +103,6 @@ provisioner:
     group_vars:
       all:
         nvidia_driver_skip_reboot: true
-        # Keep this CI-repair PR independently runnable while installable
-        # defaults are reviewed in the follow-up PRs.
-        nvidia_driver_branch: "580"
       canonical_repo:
         nvidia_driver_ubuntu_install_from_cuda_repo: false
       canonical_repo_noserver:


### PR DESCRIPTION
## Summary

Update the default NVIDIA CUDA repository keyring package from `1.0-1` to `1.1-1`.

## Why

The role constructs a versioned keyring URL. For Ubuntu 24.04 x86_64, the [`1.0-1` URL](https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.0-1_all.deb) returns 404, while the [`1.1-1` URL](https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb) is published.

On reruns where `1.1-1` is already installed, requesting the older version can also fail with "A later version is already installed." Updating the pin converges on the published version without using `force: true` or forcing a downgrade.

Direct HEAD requests returned 200 for `1.1-1` in the Ubuntu 18.04, 20.04, 22.04, and 24.04 CUDA repositories for both x86_64 and sbsa. The repaired CI matrix exercises Ubuntu 22.04 and 24.04 on x86_64; it does not exercise sbsa.

## Validation status and merge order

This pull request is stacked on #87. At head `7da9276`, its required Molecule check passed on the exact revision: [GitHub Actions run 30307979382](https://github.com/NVIDIA/ansible-role-nvidia-driver/actions/runs/30307979382). This branch removes #87's temporary keyring override so the check exercises the changed keyring default while retaining the temporary driver-branch override needed before #89.

This change fixes the keyring failure, but it does **not** by itself make the Ubuntu 24.04 CUDA scenario green: `cuda-drivers-515` is also unavailable there, which #89 addresses.

Required merge order is **#87 → #88 → #89**. Each stacked pull request must pass after removing its corresponding temporary override so the final shipped defaults—not only the overrides—are exercised.
