### PR TITLE
fix(defaults): move default driver branch to 580

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ ansible-galaxy install nvidia.nvidia_driver
 | `nvidia_driver_skip_reboot`         | `no`                            | Whether to skip rebooting the node during the install                                                                 |
 | `nvidia_driver_module_file`         | `"/etc/modprobe.d/nvidia.conf"` | Filename to use for NVIDIA driver parameters                                                                          |
 | `nvidia_driver_module_params`       | `""`                            | Parameters to pass to the NVIDIA driver                                                                               |
-| `nvidia_driver_branch`              | `"515"`                         | Default driver branch to install                                                                                      |
+| `nvidia_driver_branch`              | `"580"`                         | Default driver branch to install                                                                                      |
 
 ### Red Hat specific variables
 
@@ -40,7 +40,8 @@ $ ansible-galaxy install nvidia.nvidia_driver
 |----------------------------------------|-------------------------------------------------------------------------------------------------------------------|-----------------------------------|
 | `epel_package`                         | `"https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"` | Package to install to enable EPEL |
 | `nvidia_driver_rhel_cuda_repo_baseurl` | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/"`                                | Base URL to use for CUDA repo     |
-| `nvidia_driver_rhel_cuda_repo_gpgkey`  | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/7fa2af80.pub"`                    | GPG key for the CUDA repo         |
+| `nvidia_driver_rhel_cuda_repo_gpgkey`  | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _rhel_repo_dir }}/D42D0685.pub"`                    | GPG key for the CUDA repo         |
+| `nvidia_driver_rhel_branch`            | `"{{ nvidia_driver_branch }}"`                                                                                    | Driver branch on Red Hat family hosts |
 
 ### Ubuntu specific variables
 
@@ -50,10 +51,17 @@ By default, the Canonical repositories will be used, and the driver installed wi
 
 | Variable                                      | Default value                                                                      | Description                                          |
 |-----------------------------------------------|------------------------------------------------------------------------------------|------------------------------------------------------|
+| `nvidia_driver_ubuntu_branch`                 | `"{{ nvidia_driver_branch }}"`                                                     | Driver branch on Ubuntu hosts                        |
 | `nvidia_driver_ubuntu_install_from_cuda_repo` | `no`                                                                               | Flag whether to use the CUDA repo                    |
-| `nvidia_driver_ubuntu_cuda_repo_baseurl`      | `"http://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"` | Base URL to use for CUDA repo                        |
-| `nvidia_driver_ubuntu_cuda_package`           | `"cuda-drivers"`                                                                   | Package name to install from CUDA repo               |
+| `nvidia_driver_ubuntu_cuda_repo_baseurl`      | `"https://developer.download.nvidia.com/compute/cuda/repos/{{ _ubuntu_repo_dir }}"` | Base URL to use for CUDA repo                       |
+| `nvidia_driver_ubuntu_cuda_package`           | `"cuda-drivers-{{ nvidia_driver_ubuntu_branch }}"`                                  | Package name to install from CUDA repo              |
 | `nvidia_driver_ubuntu_packages_suffix`        | `"-server"`                                                                        | The suffix added to the apt packages when installing |
+
+On Ubuntu, the driver branch is part of the package name. If
+`nvidia_driver_package_version` pins a version from an older branch, also set
+`nvidia_driver_ubuntu_branch` (or `nvidia_driver_branch`) to that matching
+branch. A version-only pin otherwise combines the new default package name with
+an incompatible older version.
 
 ## Example playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ nvidia_driver_skip_reboot: no
 nvidia_driver_module_file: /etc/modprobe.d/nvidia.conf
 nvidia_driver_module_params: ''
 nvidia_driver_add_repos: yes
-nvidia_driver_branch: "515"
+nvidia_driver_branch: "580"
 
 
 ##############################################################################

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -103,9 +103,6 @@ provisioner:
     group_vars:
       all:
         nvidia_driver_skip_reboot: true
-        # Keep this CI-repair PR independently runnable while installable
-        # defaults are reviewed in the follow-up PRs.
-        nvidia_driver_branch: "580"
       canonical_repo:
         nvidia_driver_ubuntu_install_from_cuda_repo: false
       canonical_repo_noserver:


### PR DESCRIPTION
## Summary

Change the default NVIDIA driver branch from `515` to `580` and document the per-family branch overrides.

The existing default is not installable through the Ubuntu 24.04 CUDA-repository path because `cuda-drivers-515` is unavailable there.

## Why 580

NVIDIA identifies R580 as a data-center Long Term Support Branch with support through June 2028. NVIDIA's architecture matrix also identifies R580 as the last driver branch supporting Maxwell, Pascal, and Volta:

- [Data-center driver lifecycle](https://docs.nvidia.com/datacenter/tesla/drivers/supported-drivers-and-cuda-toolkit-versions.html)
- [CUDA toolkit, driver, and architecture matrix](https://docs.nvidia.com/datacenter/tesla/drivers/cuda-toolkit-driver-and-architecture-matrix.html)

Repository metadata was checked for the post-#87 target matrix. Branch 580 is present in:

- EL8 and EL9 NVIDIA module streams
- Ubuntu 22.04 and 24.04 archives
- Ubuntu 22.04 and 24.04 CUDA repositories as `cuda-drivers-580`

This does not mean 580 is the newest driver published for Ubuntu. Newer lines exist through other package names. The relevant constraint is the role's explicit `cuda-drivers-{{ nvidia_driver_ubuntu_branch }}` formula: the checked Ubuntu CUDA repositories' branch-suffixed packages top out at 580.

## User impact

`nvidia_driver_rhel_branch` and `nvidia_driver_ubuntu_branch` continue to derive from `nvidia_driver_branch`, and both overrides are now documented.

Hosts whose effective branch is explicitly pinned are unaffected. Pinning `nvidia_driver_branch` applies to both families; a family-specific override protects only that family.

The README also reconciles three stale documented defaults with the existing role defaults: the RHEL CUDA repository key is `D42D0685.pub`, the Ubuntu CUDA repository URL uses HTTPS, and the Ubuntu CUDA package name includes `nvidia_driver_ubuntu_branch`. Those are documentation corrections, not runtime changes.

On Ubuntu, pinning only `nvidia_driver_package_version` is not sufficient when retaining an older branch because the branch is part of the package name. Such sites must pin the Ubuntu branch as well. The RHEL package paths do not have that same package-name constraint.

Legacy or community-supported targets where branch 580 is unavailable, including Ubuntu 18.04/20.04 and EL7, must explicitly select a branch present in their repositories.

## Validation and limitations

This pull request is stacked on #88, which is stacked on #87. At head `9a25372`, its Molecule check passed on the exact revision: [GitHub Actions run 30308006107](https://github.com/NVIDIA/ansible-role-nvidia-driver/actions/runs/30308006107). This branch removes #87's remaining temporary driver-branch override so the check exercises the changed driver default; #88 already removed the keyring override.

A clean physical test at the same exact head exercised the unmodified Ubuntu default on one NVIDIA A30. The Ubuntu 24.04 x86_64 host began with no installed NVIDIA packages in the queried DKMS, headless, kernel-source, or utils families and no loaded NVIDIA modules, had Secure Boot disabled and matching kernel headers, and supplied no driver or package override to the role. The role selected Canonical's proprietary `580-server` packages at 580.159.03, completed its own conditional reboot, and reconnected with `ok=10 changed=5 failed=0 unreachable=0`. The loaded module license was `NVIDIA`, and `nvidia-smi` enumerated the expected single A30 on 580.159.03 with no current-boot Xid, `RmInitAdapter` failure, or open-module requirement.

An identical second convergence completed with `ok=9 changed=0 failed=0 unreachable=0`; all package items were already satisfied, the reboot task was skipped, the boot identity was unchanged, and the same A30 remained visible.

This validates the proprietary Canonical default only for this A30/Ubuntu 24.04 configuration. It does not validate open-kernel-module selection, Blackwell hardware, the CUDA-repository/keyring path, Red Hat-family paths, or broader hardware coverage.

An earlier physical attempt on a GPU that requires open modules therefore remains a failed Blackwell result, not contrary evidence for this A30 pass. That run installed the proprietary 580 server packages but did not enumerate the GPU; a later blanket `-open` suffix also formed the nonexistent package `nvidia-utils-580-server-open`. First-class selective open-module support remains outside this change.

Required merge order is **#87 → #88 → #89**. Require green checks against each exact integrated head and the required independent approval before merging.
