### PR TITLE
fix: Use true/false YAML literals instead of yes/no

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
   file:
     path: /etc/systemd/system/nvidia-persistenced.service.d/
     state: directory
-    recurse: yes
+    recurse: true
 
 - name: configure persistenced service to turn on persistence mode
   copy:
@@ -38,7 +38,7 @@
 - name: enable persistenced
   systemd:
     name: nvidia-persistenced
-    enabled: yes
+    enabled: true
   when: nvidia_driver_package_state != 'absent'
 
 - name: set module parameters

--- a/tests/test_yaml_booleans.sh
+++ b/tests/test_yaml_booleans.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure boolean values in tasks/main.yml use canonical YAML 1.2 literals
+if grep -E '^\s+[a-z_]+:\s*(yes|no)\s*$' tasks/main.yml; then
+    echo "ERROR: found yes/no boolean literals in tasks/main.yml"
+    exit 1
+fi


### PR DESCRIPTION
This PR addresses the following issue in `tasks/main.yml`: Use true/false YAML literals instead of yes/no.

## Changes
- `tasks/main.yml`: Use true/false YAML literals instead of yes/no.

## Details
```diff
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
-  file:
-    path: /etc/systemd/system/nvidia-persistenced.service.d/
-    state: directory
-    recurse: yes
-
-- name: enable persistenced
-  systemd:
-    name: nvidia-persistenced
-    enabled: yes
-  when: nvidia_driver_package_state != 'absent'
+  file:
+    path: /etc/systemd/system/nvidia-persistenced.service.d/
+    state: directory
+    recurse: true
+
+- name: enable persistenced
+  systemd:
+    name: nvidia-persistenced
+    enabled: true
+  when: nvidia_driver_package_state != 'absent'
```

## Tests
- `tests/test_yaml_booleans.sh`

```diff
diff --git a/tests/test_yaml_booleans.sh b/tests/test_yaml_booleans.sh
new file mode 100644
index 0000000..e69de29
--- /dev/null
+++ b/tests/test_yaml_booleans.sh
@@ -0,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure boolean values in tasks/main.yml use canonical YAML 1.2 literals
+if grep -E '^\s+[a-z_]+:\s*(yes|no)\s*$' tasks/main.yml; then
+    echo "ERROR: found yes/no boolean literals in tasks/main.yml"
+    exit 1
+fi
```