### PR TITLE
fix: version pinned in apt name even when state is absent

### DIFF
--- a/tasks/install-ubuntu.yml
+++ b/tasks/install-ubuntu.yml
@@ -6,7 +6,7 @@
 
 - name: install driver packages
   apt:
-    name: "{{ nvidia_driver_package_version | ternary(item+'='+nvidia_driver_package_version, item) }}"
+    name: "{{ item }}{{ ('=' + nvidia_driver_package_version) if (nvidia_driver_package_version | default('', true) and nvidia_driver_package_state != 'absent') else '' }}"
     state: "{{ nvidia_driver_package_state }}"
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
     purge: "{{ nvidia_driver_package_state == 'absent' }}"

--- a/tests/test_absent_version_pin.yml
+++ b/tests/test_absent_version_pin.yml
@@ -1,0 +1,22 @@
+---
+- name: Verify version pinning is omitted when package state is absent
+  hosts: localhost
+  gather_facts: false
+  vars:
+    nvidia_driver_ubuntu_packages:
+      - nvidia-driver-535
+      - nvidia-dkms-535
+    nvidia_driver_package_version: "535.104.05"
+    nvidia_driver_package_state: "absent"
+  tasks:
+    - name: compute rendered package names as the role would
+      ansible.builtin.set_fact:
+        rendered_names: "{{ rendered_names | default([]) + [item ~ suffix] }}"
+      vars:
+        suffix: "{{ ('=' + nvidia_driver_package_version) if (nvidia_driver_package_version | default('', true) and nvidia_driver_package_state != 'absent') else '' }}"
+      loop: "{{ nvidia_driver_ubuntu_packages }}"
+
+    - name: assert unversioned names are used for absent state
+      ansible.builtin.assert:
+        that:
+          - rendered_names == nvidia_driver_ubuntu_packages


### PR DESCRIPTION
This PR addresses the following issue in `tasks/install-ubuntu.yml`: version pinned in apt name even when state is absent.

## Changes
- `tasks/install-ubuntu.yml`: version pinned in apt name even when state is absent.

## Details
```diff
--- a/tasks/install-ubuntu.yml
+++ b/tasks/install-ubuntu.yml
@@ -1,2 +1,2 @@
-    name: "{{ nvidia_driver_package_version | ternary(item+'='+nvidia_driver_package_version, item) }}"
-    state: "{{ nvidia_driver_package_state }}"
+    name: "{{ item }}{{ ('=' + nvidia_driver_package_version) if (nvidia_driver_package_version | default('', true) and nvidia_driver_package_state != 'absent') else '' }}"
+    state: "{{ nvidia_driver_package_state }}"
```

## Tests
- `tests/test_absent_version_pin.yml`

```diff
--- /dev/null
+++ b/tests/test_absent_version_pin.yml
@@ -0,0 +1,22 @@
+---
+- name: Verify version pinning is omitted when package state is absent
+  hosts: localhost
+  gather_facts: false
+  vars:
+    nvidia_driver_ubuntu_packages:
+      - nvidia-driver-535
+      - nvidia-dkms-535
+    nvidia_driver_package_version: "535.104.05"
+    nvidia_driver_package_state: "absent"
+  tasks:
+    - name: compute rendered package names as the role would
+      ansible.builtin.set_fact:
+        rendered_names: "{{ rendered_names | default([]) + [item ~ suffix] }}"
+      vars:
+        suffix: "{{ ('=' + nvidia_driver_package_version) if (nvidia_driver_package_version | default('', true) and nvidia_driver_package_state != 'absent') else '' }}"
+      loop: "{{ nvidia_driver_ubuntu_packages }}"
+
+    - name: assert unversioned names are used for absent state
+      ansible.builtin.assert:
+        that:
+          - rendered_names == nvidia_driver_ubuntu_packages
+        fail_msg: "Expected unversioned package names for absent state, got {{ rendered_names }}"
```