### PR TITLE
fix: apt module cannot install .deb from remote URL

### DIFF
--- a/tasks/install-ubuntu-cuda-repo.yml
+++ b/tasks/install-ubuntu-cuda-repo.yml
@@ -11,9 +11,17 @@
   environment: "{{proxy_env if proxy_env is defined else {}}}"
   when: nvidia_driver_add_repos | bool
 
+- name: download CUDA keyring package
+  get_url:
+    url: "{{ nvidia_driver_ubuntu_cuda_keyring_url }}"
+    dest: "/tmp/{{ nvidia_driver_ubuntu_cuda_keyring_url | basename }}"
+    mode: '0644'
+  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  when: nvidia_driver_add_repos | bool
+
 - name: add CUDA keyring
   apt:
-    deb: "{{ nvidia_driver_ubuntu_cuda_keyring_url }}"
+    deb: "/tmp/{{ nvidia_driver_ubuntu_cuda_keyring_url | basename }}"
     state: "present"
   environment: "{{proxy_env if proxy_env is defined else {}}}"
   when: nvidia_driver_add_repos | bool


### PR DESCRIPTION
This PR addresses the following issue in `tasks/install-ubuntu-cuda-repo.yml`: apt module cannot install .deb from remote URL.

## Changes
- `tasks/install-ubuntu-cuda-repo.yml`: apt module cannot install .deb from remote URL.

## Details
```diff
--- a/tasks/install-ubuntu-cuda-repo.yml
+++ b/tasks/install-ubuntu-cuda-repo.yml
@@ -1,6 +1,14 @@
-- name: add CUDA keyring
-  apt:
-    deb: "{{ nvidia_driver_ubuntu_cuda_keyring_url }}"
-    state: "present"
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
-  when: nvidia_driver_add_repos | bool
+- name: download CUDA keyring package
+  get_url:
+    url: "{{ nvidia_driver_ubuntu_cuda_keyring_url }}"
+    dest: "/tmp/{{ nvidia_driver_ubuntu_cuda_keyring_url | basename }}"
+    mode: '0644'
+  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  when: nvidia_driver_add_repos | bool
+
+- name: add CUDA keyring
+  apt:
+    deb: "/tmp/{{ nvidia_driver_ubuntu_cuda_keyring_url | basename }}"
+    state: "present"
+  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  when: nvidia_driver_add_repos | bool
```

## Tests
- `molecule/default/verify.yml`

```diff
--- /dev/null
+++ b/molecule/default/verify.yml
@@ -0,0 +1,7 @@
+---
+- name: Verify CUDA keyring package is installed
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: check that the cuda-keyring package is installed
+      ansible.builtin.command: dpkg-query -W cuda-keyring
+      changed_when: false
```