### PR TITLE
fix: cast ansible_distribution_major_version to int before comparing

### DIFF
--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -70,7 +70,7 @@
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
   register: install_driver_rhel7
   environment: "{{proxy_env if proxy_env is defined else {}}}"
-  when: ansible_distribution_major_version < '8'
+  when: ansible_distribution_major_version is version('8', '<')
 
 - name: install driver packages RHEL/CentOS 8 and newer
   dnf:
@@ -79,7 +79,7 @@
     autoremove: "{{ nvidia_driver_package_state == 'absent' }}"
   register: install_driver_rhel8
   environment: "{{proxy_env if proxy_env is defined else {}}}"
-  when: ansible_distribution_major_version > '7'
+  when: ansible_distribution_major_version is version('7', '>')
 
 - name: Set install_driver.changed var for RHEL 7/8
   debug:

--- a/tests/test_version_conditions.yml
+++ b/tests/test_version_conditions.yml
@@ -1,0 +1,20 @@
+---
+- name: Verify RHEL/CentOS major version comparisons
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: set test versions
+      set_fact:
+        test_versions:
+          - { version: "7", rhel7: true, rhel8: false }
+          - { version: "8", rhel7: false, rhel8: true }
+          - { version: "9", rhel7: false, rhel8: true }
+          - { version: "10", rhel7: false, rhel8: true }
+
+    - name: assert version comparisons behave as expected
+      assert:
+        that:
+          - (item.version is version('8', '<')) == item.rhel7
+          - (item.version is version('7', '>')) == item.rhel8
+        fail_msg: "Version comparison failed for major version {{ item.version }}"
+      loop: "{{ test_versions }}"


### PR DESCRIPTION
This PR addresses the following issue in `tasks/install-redhat.yml`: cast ansible_distribution_major_version to int before comparing.

## Changes
- `tasks/install-redhat.yml`: cast ansible_distribution_major_version to int before comparing.

## Details
```diff
--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -1,5 +1,5 @@
-  when: ansible_distribution_major_version < '8'
-
-...
-
-  when: ansible_distribution_major_version > '7'
+  when: ansible_distribution_major_version is version('8', '<')
+
+...
+
+  when: ansible_distribution_major_version is version('7', '>')
```

## Tests
- `tests/test_version_conditions.yml`

```diff
--- /dev/null
+++ b/tests/test_version_conditions.yml
@@ -0,0 +1,20 @@
+---
+- name: Verify RHEL/CentOS major version comparisons
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: set test versions
+      set_fact:
+        test_versions:
+          - { version: "7", rhel7: true, rhel8: false }
+          - { version: "8", rhel7: false, rhel8: true }
+          - { version: "9", rhel7: false, rhel8: true }
+          - { version: "10", rhel7: false, rhel8: true }
+
+    - name: assert version comparisons behave as expected
+      assert:
+        that:
+          - (item.version is version('8', '<')) == item.rhel7
+          - (item.version is version('7', '>')) == item.rhel8
+        fail_msg: "Version comparison failed for major version {{ item.version }}"
+      loop: "{{ test_versions }}"
```